### PR TITLE
Comment to clarify an example in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ You can also change both the split delimiter and limit
     opts = Slop.parse do
       opt :people, true, :as => Array, :delimiter => ':', :limit => 2)
     end
+
+    # ARGV is `--people lee:injekt:bob`
     opts[:people] #=> ["lee", "injekt:bob"]
 
 Woah woah, why you hating on OptionParser?


### PR DESCRIPTION
Slop is awesome! I just added a little comment to the readme to clarify the example of an array option with a custom delimiter and limit.
