### PR TITLE
Trash items prefixed with --no-

### DIFF
--- a/lib/slop.rb
+++ b/lib/slop.rb
@@ -207,15 +207,13 @@ private
           option = @options[$1]
           argument = $2
         when /--no-(.+)$/
-          if option = @options[$1]
-            option.force_argument_value false
-            next
-          end
+          option.force_argument_value(false) if option = @options[$1]
         end
       end
 
       if option
         trash << item
+        next if option.forced?
         option.argument_value = true
 
         if option.expects_argument? || option.accepts_optional_argument?

--- a/lib/slop/option.rb
+++ b/lib/slop/option.rb
@@ -136,6 +136,10 @@ class Slop
       @forced = true
     end
 
+    def forced?
+      @forced
+    end
+
     def to_s
       out = "    "
       out += @short_flag ? "-#{@short_flag}, " : ' ' * 4

--- a/test/slop_test.rb
+++ b/test/slop_test.rb
@@ -101,6 +101,12 @@ class SlopTest < TestCase
     assert_empty items
   end
 
+  test '#parse! removes parsed items prefixed with --no-' do
+    items = %w/--no-foo/
+    Slop.new { |opt| opt.on :foo }.parse!(items)
+    assert_empty items
+  end
+
   test 'the shit out of clean_options' do
     assert_equal(
       ['s', 'short', 'short option', false],


### PR DESCRIPTION
Hi
Just noticed that the items prefixed with '--no-' weren't removed from the list of arguments when using parse!
I fixed it and added a test.
Cheers
