### PR TITLE
support for summary and description

### DIFF
--- a/lib/slop.rb
+++ b/lib/slop.rb
@@ -51,15 +51,15 @@ class Slop
   #   @param [String] string The text to set the banner to
   attr_writer :banner
 
-  # @overload short_desc=(string)
-  #   Set the short description
-  #   @param [String] string The text to set the short description to
-  attr_writer :short_desc
+  # @overload summary=(string)
+  #   Set the summary
+  #   @param [String] string The text to set the summary to
+  attr_writer :summary
 
-  # @overload long_desc=(string)
-  #   Set the long description
-  #   @param [String] string The text to set the long description to
-  attr_writer :long_desc
+  # @overload description=(string)
+  #   Set the description
+  #   @param [String] string The text to set the description to
+  attr_writer :description
 
   # @return [Integer] The length of the longest flag slop knows of
   attr_accessor :longest_flag
@@ -148,30 +148,30 @@ class Slop
     @banner
   end
 
-  # Set or return the short description
+  # Set or return the summary
   #
-  # @param [String] text Displayed short description text
+  # @param [String] text Displayed summary text
   # @example
   #   opts = Slop.parse do
-  #     short_desc "do stuff with more stuff"
+  #     summary "do stuff with more stuff"
   #   end
-  # @return [String] The current short description
-  def short_desc(text=nil)
-    @short_desc = text if text
-    @short_desc
+  # @return [String] The current summary
+  def summary(text=nil)
+    @summary = text if text
+    @summary
   end
 
-  # Set or return the long description
+  # Set or return the description
   #
-  # @param [String] text Displayed long description text
+  # @param [String] text Displayed description text
   # @example
   #   opts = Slop.parse do
-  #     long_desc "This command does a lot of stuff with other stuff."
+  #     description "This command does a lot of stuff with other stuff."
   #   end
-  # @return [String] The current long description
-  def long_desc(text=nil)
-    @long_desc = text if text
-    @long_desc
+  # @return [String] The current description
+  def description(text=nil)
+    @description = text if text
+    @description
   end
 
   # Parse a list of options, leaving the original Array unchanged
@@ -374,8 +374,8 @@ class Slop
     parts = []
 
     parts << banner if banner
-    parts << short_desc if short_desc
-    parts << wrap_and_indent(long_desc, 80, 4) if long_desc
+    parts << summary if summary
+    parts << wrap_and_indent(description, 80, 4) if description
     parts << "options:" if options.size > 0
     parts << options.to_help if options.size > 0
 

--- a/test/slop_test.rb
+++ b/test/slop_test.rb
@@ -140,27 +140,27 @@ class SlopTest < TestCase
     assert_equal "foo bar", slop.banner
   end
 
-  test 'setting the short description' do
+  test 'setting the summary' do
     slop = Slop.new
     slop.banner = "foo bar"
-    slop.short_desc = "does stuff"
+    slop.summary = "does stuff"
 
     assert_equal "foo bar\n\ndoes stuff", slop.to_s
   end
 
-  test 'setting the long description' do
+  test 'setting the description' do
     slop = Slop.new
     slop.banner     = "foo bar"
-    slop.short_desc = "does stuff"
-    slop.long_desc  = "This does stuff."
+    slop.summary = "does stuff"
+    slop.description  = "This does stuff."
 
     assert_equal "foo bar\n\ndoes stuff\n\n    This does stuff.", slop.to_s
   end
 
-  test 'setting the long description without matching short description' do
+  test 'setting the description without matching summary' do
     slop = Slop.new
     slop.banner     = "foo bar"
-    slop.long_desc  = "This does stuff."
+    slop.description  = "This does stuff."
 
     assert_equal "foo bar\n\n    This does stuff.", slop.to_s
   end


### PR DESCRIPTION
This adds support for summaries and descriptions that show up in the command’s help text. Inspired by nanoc’s help, which in turn was inspired by Mercurial’s help.
