### PR TITLE
Support :as => 'count'

### DIFF
--- a/lib/slop.rb
+++ b/lib/slop.rb
@@ -143,6 +143,9 @@ class Slop
     #   according to the `:as` option
     def argument_value
       return @argument_value if forced
+      # Check for count first to prefer 0 over nil
+      return count if @argument_type == 'count'
+
       value = @argument_value || @options[:default]
       return if value.nil?
 

--- a/test/option_test.rb
+++ b/test/option_test.rb
@@ -75,6 +75,11 @@ class OptionTest < TestCase
     assert_equal -1, option_value(%w/-i -1.1/, :i, true, :as => Integer)
     assert_equal "-1.1", option_value(%w/-i -1.1/, :i, true, :as => Float).to_s
     assert_equal "foo", option_value(%w/--foo1 foo/, :foo1, true)
+
+    assert_equal 0, option_value(%w//, :v, :verbose, :as => :count)
+    assert_equal 1, option_value(%w/--verbose/, :v, :verbose, :as => :count)
+    assert_equal 2, option_value(%w/--verbose -v/, :v, :verbose, :as => :count)
+    assert_equal 3, option_value(%w/-vvv/, :v, :verbose, :as => :count)
   end
 
   test 'ranges' do


### PR DESCRIPTION
This simplifies the API when you want to count arguments.

The typical example is -v for verbose, -vv for very-verbose.
