### PR TITLE
fix checking of required options

### DIFF
--- a/lib/slop.rb
+++ b/lib/slop.rb
@@ -881,7 +881,7 @@ class Slop
 
   def raise_if_missing_required_options!(items)
     @options.select(&:required).each do |o|
-      unless items.select {|i| i[/\A--?/] }.any? {|i| i.to_s.sub(/\A--?/, '') == o.key }
+      if o.argument_value.nil?
         raise MissingOptionError, "Expected option `#{o.key}` is required"
       end
     end


### PR DESCRIPTION
Slop was checking if the list of arguments contained the long-name
version of an option to check if a required option was indeed supplied.

This obviously doesn't work if a required option was given by using
it's short name instead.

A saner way of checking if an option was given is by checking if the
argument_value of the option is not nil, as there is no way for the
user to supply nil as a valid value.
