### PR TITLE
New config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ All of these options can be sent to `Slop.new` or `Slop.parse` in Hash form.
 * `banner` - Set this options banner text. **default:** *nil*.
 * `ignore_case` - When enabled, `-A` will look for the `-a` option if `-A`
   does not exist. **default:** *false*.
+* `support_dash` - Will treat --no-database as if you typed in --no_database.
+  **default:** *false*
 * `autocreate` - Autocreate options on the fly. **default:** *false*.
 * `arguments` - Force all options to expect arguments. **default:** *false*.
 * `optional_arguments` - Force all options to accept optional arguments.

--- a/lib/slop.rb
+++ b/lib/slop.rb
@@ -30,6 +30,7 @@ class Slop
     :help => false,
     :banner => nil,
     :ignore_case => false,
+    :support_dash => false,
     :autocreate => false,
     :arguments => false,
     :optional_arguments => false,
@@ -481,6 +482,7 @@ class Slop
   def extract_option(flag)
     option = fetch_option(flag)
     option ||= fetch_option(flag.downcase) if config[:ignore_case]
+    option ||= fetch_option(flag.gsub /([^-])-/, '\1_') if config[:support_dash]
 
     unless option
       case flag

--- a/test/slop_test.rb
+++ b/test/slop_test.rb
@@ -243,6 +243,16 @@ class SlopTest < TestCase
     assert_equal 'bar', opts[:foo]
   end
 
+  test "supporting dash" do
+    opts = Slop.new {on :foo_bar=}
+    opts.parse %w' --foo-bar baz '
+    assert_nil opts[:foo_bar]
+
+    opts = Slop.new(:support_dash => true) { on :foo_bar= }
+    opts.parse %w' --foo-bar baz '
+    assert_equal 'baz', opts[:foo_bar]
+  end
+
   test "parsing an optspec and building options" do
     optspec = <<-SPEC
     ruby foo.rb [options]


### PR DESCRIPTION
To better support dashes in options without having to jump through hoops in the Ruby code. Made it off by default but you can feel free to remove the option and instead just make it always enabled if you feel that is safe to do.
