### PR TITLE
Fix option terminator parsing

### DIFF
--- a/lib/slop.rb
+++ b/lib/slop.rb
@@ -374,7 +374,8 @@ class Slop
       @trash << index && break if item == '--'
       autocreate(items, index) if config[:autocreate]
       process_item(items, index, &block) unless @trash.include?(index)
-    }.reject!.with_index { |item, index| delete && @trash.include?(index) }
+    }
+    items.reject!.with_index { |item, index| delete && @trash.include?(index) }
 
     required_options = options.select { |opt| opt.required? && opt.count < 1 }
     if required_options.any?


### PR DESCRIPTION
Breaking out of a block returns nil, not an array, so an excetion is raised when trying to parse an array containig the option terminator (`--`), e.g. `Slop.parse(%w(--foo -- bar)){ on :foo }`
