### PR TITLE
An explicit test for underscore support.

### DIFF
--- a/test/slop_test.rb
+++ b/test/slop_test.rb
@@ -263,6 +263,13 @@ class SlopTest < TestCase
     assert opts.foo_bar?
   end
 
+  test "supporting underscore" do
+    opts = Slop.new { on :foo_bar= }
+    opts.parse %w' --foo_bar baz '
+    assert_equal 'baz', opts[:foo_bar]
+    assert opts.foo_bar?
+  end
+
   test "parsing an optspec and building options" do
     optspec = <<-SPEC
     ruby foo.rb [options]


### PR DESCRIPTION
I think this test would help users realize that both dash and underscore switches are referenced in the same fashion.
