### PR TITLE
option max_count (strict only) 

### DIFF
--- a/lib/slop.rb
+++ b/lib/slop.rb
@@ -15,6 +15,9 @@ class Slop
   # Raised when an option is expected/required but not present.
   class MissingOptionError < Error; end
 
+  # Raised when an option is repeated more times than allowed.
+  class TooManyRepeatedOptionsError < Error; end
+
   # Raised when an argument does not match its intended match constraint.
   class InvalidArgumentError < Error; end
 

--- a/lib/slop/option.rb
+++ b/lib/slop/option.rb
@@ -11,6 +11,7 @@ class Slop
       :delimiter => ',',
       :limit => 0,
       :match => nil,
+      :max_count => nil,
       :optional => true,
       :required => false,
       :as => String,
@@ -18,7 +19,7 @@ class Slop
     }
 
     attr_reader :short, :long, :description, :config, :types
-    attr_accessor :count
+    attr_reader :count
     attr_writer :value
 
     # Incapsulate internal option information, mainly used to store
@@ -72,6 +73,17 @@ class Slop
     # Returns the String flag of this option. Preferring the long flag.
     def key
       long || short
+    end
+
+    # Ensure that count stays below the threshold when strict
+    def count=(new_count)
+      if @slop.strict?
+        max_count=config[:max_count]
+        if max_count.is_a?(::Integer) && new_count > max_count
+          raise TooManyRepeatedOptionsError, "#{key} is only allowed #{max_count} time(s)"
+        end
+      end
+      @count = new_count 
     end
 
     # Call this options callback if one exists, and it responds to call().

--- a/test/slop_test.rb
+++ b/test/slop_test.rb
@@ -184,6 +184,23 @@ class SlopTest < TestCase
     assert_equal %w' foo --foo bar ', items
   end
 
+  test "repeated options are allowed up to max_count with strict" do
+    opts = Slop.new(:strict => true) { on :v, :max_count => 2 }
+    opts.parse %w' -vv' 
+    assert_equal opts.fetch_option(:v).count, 2
+  end
+
+  test "repeated options are allowed beyond max_count without strict" do
+    opts = Slop.new(:strict => false) { on :v, :max_count => 2 }
+    opts.parse %w' -vvv' 
+    assert_equal opts.fetch_option(:v).count, 3
+  end
+
+  test "raising an TooManyRepeatedOptionsError when too many arguments are passed" do
+    opts = Slop.new(:strict => true) { on :v, :max_count => 2 }
+    assert_raises(Slop::TooManyRepeatedOptionsError) { opts.parse %w' -vvv' }
+  end
+
   test "raising an InvalidArgumentError when the argument doesn't match" do
     opts = Slop.new { on :foo=, :match => /^[a-z]+$/ }
     assert_raises(Slop::InvalidArgumentError) { opts.parse %w' --foo b4r '}


### PR DESCRIPTION
Implemented `max_count` for maximum repeated option count.

The use-case is when an option may appear, at most, `max_count` times.

Example: `on :v, :max_count => 3`  ===> `foo -vvv` (but not `foo -vvvv -v`)

All tests pass.
