### PR TITLE
sweep warnings on ruby-1.9.n

### DIFF
--- a/lib/slop.rb
+++ b/lib/slop.rb
@@ -433,7 +433,7 @@ class Slop
       elsif option.accepts_optional_argument?
         argument ||= items.at(index + 1)
 
-        if argument && argument =~ /\A([^-\-?]|-\d)+/
+        if argument && argument =~ /\A([^\-?]|-\d)+/
           execute_option(option, argument, index, item)
         else
           option.call(nil)

--- a/lib/slop/option.rb
+++ b/lib/slop/option.rb
@@ -38,6 +38,7 @@ class Slop
       @config = DEFAULT_OPTIONS.merge(config)
       @count = 0
       @callback = block_given? ? block : config[:callback]
+      @value = nil
 
       @types = {
         :string  => proc { |v| v.to_s },
@@ -53,7 +54,10 @@ class Slop
       end
 
       @config.each_key do |key|
-        self.class.send(:define_method, "#{key}?") { !!@config[key] }
+        predicate = :"#{key}?"
+        unless self.class.method_defined? predicate
+          self.class.send(:define_method, predicate) { !!@config[key] }
+        end
       end
     end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,3 +1,5 @@
+$VERBOSE = true
+
 unless Object.const_defined? 'Slop'
   $:.unshift File.expand_path('../../lib', __FILE__)
   require 'slop'


### PR DESCRIPTION
## Suggestions

1.
- enable the warning option in test-helper

2.
- sweep warnings for redefined methods
- sweep warnings for regexp literal
- sweep warnings for undefined instance variable
## Note

The changing regex is just to remove warnings.
I haven't understand the meanings of the first regex goal.

```
/\A([^-\-?]|-\d)+/
```
