### PR TITLE
Improve Slop commands

### DIFF
--- a/lib/slop/commands.rb
+++ b/lib/slop/commands.rb
@@ -2,7 +2,7 @@ class Slop
   class Commands
     include Enumerable
 
-    attr_reader :config, :commands
+    attr_reader :config, :commands, :arguments
     attr_writer :banner
 
     # Create a new instance of Slop::Commands and optionally build
@@ -164,6 +164,7 @@ class Slop
     def parse_items(items, bang = false)
       if opts = commands[items[0].to_s]
         @triggered_command = items.shift
+        execute_arguments(items, bang)
         bang ? opts.parse!(items) : opts.parse(items)
         execute_global_opts(items, bang)
       else
@@ -179,6 +180,13 @@ class Slop
       items
     end
 
+    # Returns nothing.
+    def execute_arguments(items, bang)
+      @arguments = items.take_while { |arg| !arg.start_with?('-') }
+      items.shift(@arguments.size) if bang
+    end
+
+    # Returns nothing.
     def execute_global_opts(items, bang)
       if global_opts = commands['global']
         bang ? global_opts.parse!(items) : global_opts.parse(items)

--- a/test/commands_test.rb
+++ b/test/commands_test.rb
@@ -83,14 +83,20 @@ class CommandsTest < TestCase
     items = %w( foo bar baz )
     assert_equal items, @commands.parse(items)
 
-    items = %w( new --force )
+    items = %w( new file --force )
     assert_equal items, @commands.parse(items)
   end
 
   test "parse! removes options/arguments" do
-    items = %w( new --outdir foo )
+    items = %w( new file --outdir foo )
     @commands.parse!(items)
     assert_equal [], items
+  end
+
+  test "command arguments" do
+    items = %w( new file1 file2 --outdir foo )
+    @commands.parse(items)
+    assert_equal %w( file1 file2 ), @commands.arguments
   end
 
 end


### PR DESCRIPTION
Partially fixes #72.

In this pull request:
##### Add `Slop::Commands#present?` method

Extend current Commands by adding a convenient method, which helps to use such code as:

``` ruby
if cmds.present?(:install)
  run_installer
else
  # Do something else.
end
```

Example:

``` ruby
cmds.parse %w( foo )
cmds.present?(:foo) #=> true
cmds.present?(:bar) #=> false
```
##### Implement basic support for command arguments

Example:

``` ruby
cmds.parse %w( install geronimo banzai --outdir dir )
cmds.arguments #=> ["geronimo", "banzai"]
```
