### PR TITLE
Specify the target ruby versions in gemspec.

### DIFF
--- a/slop.gemspec
+++ b/slop.gemspec
@@ -9,6 +9,8 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files`.split("\n")
   s.test_files  = `git ls-files -- test/*`.split("\n")
 
+  s.required_ruby_version = '>= 1.8.7'
+
   s.add_development_dependency 'rake'
   s.add_development_dependency 'minitest'
 end


### PR DESCRIPTION
I guess, Slop target ruby vesions are 1.8.7 or later.
Because below codes, and .travis.yml.

``` ruby
&:to_s
```

I am glad that policy becomes clear.
