### PR TITLE
BlockScope of "Slop::Commands#new" is influenced by arity number

### DIFF
--- a/lib/slop/commands.rb
+++ b/lib/slop/commands.rb
@@ -40,7 +40,15 @@ class Slop
       @triggered_command = nil
 
       if block_given?
-        block.arity == 1 ? yield(self) : instance_eval(&block)
+        case block.arity.abs
+        when 0
+          instance_exec(&block)
+        when 1
+          instance_exec(self, &block)
+        else
+          raise ArgumentError,
+            "wrong number of block arguments (#{block.arity} for #{0..1})"
+        end
       end
     end
 

--- a/test/commands_test.rb
+++ b/test/commands_test.rb
@@ -99,4 +99,18 @@ class CommandsTest < TestCase
     assert_equal %w( file1 file2 ), @commands.arguments
   end
 
+  test "new with block scope" do
+    peep = nil
+    ret = Slop::Commands.new { peep = self }
+    assert_same ret, peep
+
+    peep = nil
+    ret = Slop::Commands.new { |a| peep = self }
+    assert_same ret, peep
+
+    assert_raises ArgumentError do
+      Slop::Commands.new { |a, b| }
+    end
+  end
+
 end


### PR DESCRIPTION
Is this expected behavior?

ruby 1.9.3p194 (2012-04-20 revision 35410) [i686-linux]

``` ruby
p Slop::Commands.new {||p __id__}.__id__  #=> same
p Slop::Commands.new {|_|p __id__}.__id__ #=> differrent
```
