### PR TITLE
BlockScope of Slop constructors, they are influenced by arity number (same as #81)

### DIFF
--- a/lib/slop.rb
+++ b/lib/slop.rb
@@ -144,7 +144,15 @@ class Slop
     @separators = {}
 
     if block_given?
-      block.arity == 1 ? yield(self) : instance_eval(&block)
+       case block.arity.abs
+       when 0
+         instance_exec(&block)
+       when 1
+         instance_exec(self, &block)
+       else
+         raise ArgumentError,
+           "wrong number of block arguments (#{block.arity} for #{0..1})"
+       end
     end
 
     if config[:help]

--- a/test/slop_test.rb
+++ b/test/slop_test.rb
@@ -344,4 +344,30 @@ class SlopTest < TestCase
     assert_equal %w' baz hello ', args
   end
 
+  test "return value of constructors, with block scope" do
+    peep = nil
+    ret = Slop.new { peep = self }
+    assert_same ret, peep
+
+    peep = nil
+    ret = Slop.new { |a| peep = self }
+    assert_same ret, peep
+
+    assert_raises ArgumentError do
+      Slop.new { |a, b| }
+    end
+
+    peep = nil
+    ret = Slop.parse([]) { peep = self }
+    assert_same ret, peep
+
+    peep = nil
+    ret = Slop.parse([]) { |a| peep = self }
+    assert_same ret, peep
+
+    assert_raises ArgumentError do
+      Slop.parse([]) { |a, b| }
+    end
+  end
+
 end


### PR DESCRIPTION
``` ruby
p Slop.parse([]){p __id__}.__id__    #=> same
p Slop.parse([]){|_|p __id__}.__id__ #=> different
```

I'm afraid of that looks as #81.
