### PR TITLE
Don't always append global/default headers

### DIFF
--- a/lib/slop/commands.rb
+++ b/lib/slop/commands.rb
@@ -157,8 +157,12 @@ class Slop
       defaults = commands.delete('default')
       globals = commands.delete('global')
       helps = commands.reject { |_, v| v.options.none? }
-      helps.merge!('Global options' => globals.to_s) if globals
-      helps.merge!('Other options' => defaults.to_s) if defaults
+      if globals && globals.options.any?
+        helps.merge!('Global options' => globals.to_s)
+      end
+      if defaults && defaults.options.any?
+        helps.merge!('Other options' => defaults.to_s)
+      end
       banner = @banner ? "#{@banner}\n" : ""
       banner + helps.map { |key, opts| "  #{key}\n#{opts}" }.join("\n\n")
     end

--- a/test/commands_test.rb
+++ b/test/commands_test.rb
@@ -13,6 +13,16 @@ class CommandsTest < TestCase
         add_callback(:empty) { 'version 1' }
       end
     end
+
+    @empty_commands = Slop::Commands.new do
+      default do
+      end
+
+      global do
+      end
+
+      on 'verbose'
+    end
   end
 
   test "it nests instances of Slop" do
@@ -73,6 +83,10 @@ class CommandsTest < TestCase
     assert_kind_of Slop, @commands.on('foo')
     assert_kind_of Slop, @commands.default
     assert_kind_of Slop, @commands.global
+  end
+
+  test "empty default/global blocks don't add their titles in the help output" do
+    assert_empty @empty_commands.to_s
   end
 
   test "parse does nothing when there's nothing to parse" do


### PR DESCRIPTION
``` ruby
commands = Slop::Commands.new do
  default do
  end

  global do
  end

  on 'version'
end

p commands.to_s
#=> "  Global options\n\n\n  Other options\n"
```

Invokations of `global` or `default` methods with bare blocks (that is,
without option declarations) appends to the `helps` local variable
unwanted information, which results in this:

```
% my_cli_app --help
  Global options

  Other options
%
```

Fix it by checking whether global or default options, actually, have any
options defined.
