### PR TITLE
Added unknown_args method that returns arguments unknown to slop.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ doc
 *.gem
 *.rbc
 Gemfile.lock
+.idea

--- a/lib/slop.rb
+++ b/lib/slop.rb
@@ -121,6 +121,9 @@ class Slop
   # The Hash of sub-commands for this Slop instance.
   attr_reader :commands
 
+  # The array of unknown arguments in format similar to ARGV
+  attr_reader :unknown_args
+
   # Create a new instance of Slop and optionally build options via a block.
   #
   # config - A Hash of configuration options.
@@ -132,6 +135,7 @@ class Slop
     @trash = []
     @triggered_options = []
     @unknown_options = []
+    @unknown_args = []
     @callbacks = {}
     @separators = {}
     @runner = nil
@@ -515,6 +519,7 @@ class Slop
       end
     else
       @unknown_options << item if strict? && item =~ /\A--?/
+      @unknown_args << item
       block.call(item) if block && !@trash.include?(index)
     end
   end

--- a/test/slop_test.rb
+++ b/test/slop_test.rb
@@ -457,4 +457,13 @@ class SlopTest < TestCase
     assert_equal 'second', i
   end
 
+  test "method unknown_args returns an array of unknown arguments" do
+    opts = Slop.parse(%w(-o test.rb -u --env prod --tag 2 --tag 3)) do
+      on :o, :argument => :optional
+      on :env, :argument => true
+    end
+
+    assert_equal opts.unknown_args, %w(-u --tag 2 --tag 3)
+  end
+
 end


### PR DESCRIPTION
This tiny feature is very useful when slop should handle a limited number of arguments and all other arguments should be passed to another command (some kind of wrapper).
