### PR TITLE
Fix for documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ require 'slop'
 
 opts = Slop.parse do
   on :n, :name=, 'Your name'
-  on :a, :age=, 'Your age', :as => :int
+  on :a, :age=, 'Your age', as: Integer
 end
 
 opts.to_hash #=> { :name => 'lee', :age => 105 }


### PR DESCRIPTION
Update the documentation for Ruby's 1.9 hash syntax, and fix the example for the `:as` argument
