### PR TITLE
Allow specifying long options starting with numbers

### DIFF
--- a/lib/slop.rb
+++ b/lib/slop.rb
@@ -654,7 +654,7 @@ class Slop
   # config  - The Hash of configuration options built in #build_option.
   def extract_long_flag(objects, config)
     flag = objects.first.to_s
-    if flag =~ /\A(?:--?)?[a-zA-Z][a-zA-Z0-9_-]+\=?\??\z/
+    if flag =~ /\A(?:--?)?[a-zA-Z0-9][a-zA-Z0-9_.-]+\=?\??\z/
       config[:argument] ||= true if flag.end_with?('=')
       config[:optional_argument] = true if flag.end_with?('=?')
       objects.shift

--- a/test/slop_test.rb
+++ b/test/slop_test.rb
@@ -36,6 +36,7 @@ class SlopTest < TestCase
     assert_equal [nil, 'foo', nil, {}], build_option(:foo)
     assert_equal ['f', nil, 'Some description', {}], build_option(:f, 'Some description')
     assert_equal ['f', 'foo', nil, {}], build_option(:f, :foo)
+    assert_equal [nil, '1.8', 'Use v. 1.8', {}], build_option('--1.8', 'Use v. 1.8')
 
     # with arguments
     assert_equal ['f', nil, nil, {:argument=>true}], build_option('f=')


### PR DESCRIPTION
It is sometimes useful for a program to accept a version as an option (say, --19 or --1.9).
