### PR TITLE
Allow subclass to handle initialization

### DIFF
--- a/lib/slop.rb
+++ b/lib/slop.rb
@@ -61,7 +61,7 @@ class Slop
     # Returns a new instance of Slop.
     def parse!(items = ARGV, config = {}, &block)
       config, items = items, ARGV if items.is_a?(Hash) && config.empty?
-      slop = Slop.new config, &block
+      slop = new config, &block
       slop.parse! items
       slop
     end


### PR DESCRIPTION
It's a small change but it allows a subclass of Slop to initialize the
options (or some of the options). Example:

```
class Opts < Slop
  def initialize config={}
    config[:help] = true

    super config do
      on 'v', 'verbose', 'Enable verbose mode'
    end
  end
end
```

Now in my executable I do:

```
opts = Opts.parse
```

Now my options are defined by a class. I could even make my class take a block
and futher allow defination of the options.
