### PR TITLE
Allow commands to be anywhere in the command line

### DIFF
--- a/lib/slop.rb
+++ b/lib/slop.rb
@@ -230,12 +230,14 @@ class Slop
     # times with the same instance
     @trash.clear
 
-    if cmd = @commands[items[0]]
-      items.shift
-      return cmd.parse! items
-    end
-
     items.each_with_index do |item, index|
+      if cmd = @commands[item]
+        items.shift
+        @trash << index
+        cmd.parse! items[index..-1]
+        break
+      end
+
       @trash << index && break if item == '--'
       autocreate(items, index) if config[:autocreate]
       process_item(items, index, &block) unless @trash.include?(index)

--- a/test/options_and_commands_test.rb
+++ b/test/options_and_commands_test.rb
@@ -1,0 +1,21 @@
+require 'helper'
+
+class OptionsAndCommandsTest < TestCase
+
+  test "allows options before and after commands" do
+    command_line = %w'-application slop add -m TheMessage'
+
+    opts = Slop.parse! command_line, :strict => true do
+      on :a, :application=
+
+      command :add do
+        on :m, :message=
+      end
+    end
+
+    assert_equal "slop", opts[:application]
+    assert_equal "TheMessage", opts.fetch_command(:add)[:message]
+  end
+
+
+end


### PR DESCRIPTION
Slop currently doesn't support CLI tools that have a set of global options, a command, and a set of command options. This change allows such tools to work.

This obviously can open up the CLI to some confusion, as mistyping a global command can accidentally pick up the command name as an option, but I feel that's an acceptable risk for the CLI I'm currently developing.
