### PR TITLE
clarify remaining arguments example

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ The *parse!*  method will remove any options and option arguments from the origi
 opts = Slop.parse! do
   on :foo
 end
-remaining_args = ARGV
 ```
 
 Example:
@@ -156,7 +155,8 @@ ruby restarguments.rb --foo bar
 
 ```
 opts.to_hash = { :foo => true }
-remaining_args =bar
+
+ARGV #=> ["bar"]
 ```
 
 Woah woah, why you hating on OptionParser?


### PR DESCRIPTION
It took me a while to realize what the documentation was saying about `parse!` stripping items from ARGV. I included a more explicit example to help others like me.
