### PR TITLE
Default values on options are printed in the help message

### DIFF
--- a/lib/slop/option.rb
+++ b/lib/slop/option.rb
@@ -138,7 +138,12 @@ class Slop
         out << (' ' * (@slop.config[:longest_flag] + 8))
       end
 
-      "#{out}#{description}"
+      if config[:default]
+        default = config[:default]
+        "#{out}#{description} (default: #{default})"
+      else
+        "#{out}#{description}"
+      end
     end
     alias help to_s
 

--- a/test/option_test.rb
+++ b/test/option_test.rb
@@ -130,6 +130,13 @@ class OptionTest < TestCase
     assert_equal "    -V,             Display the version", slop.fetch_option(:V).help
   end
 
+  test "printing options that have defaults" do
+    opts = Slop.new
+    opts.on :n, :name=, 'Your name', :default => 'Lee'
+
+    assert_equal "    -n, --name      Your name (default: Lee)", opts.fetch_option(:name).to_s
+  end
+
   test "overwriting the help text" do
     slop = Slop.new
     slop.on :foo, :help => '    -f, --foo  SOMETHING FOOEY'


### PR DESCRIPTION
When a user provides a default value for an option, e.g.

``` ruby
  on :n, :name=, 'Your name', :default => 'Lee'
```

Show the value in the help message, e.g.

```
"    -n, --name      Your name (default: Lee)"
```
