### PR TITLE
Remove "--" from the unprocessed arguments

### DIFF
--- a/lib/slop/parser.rb
+++ b/lib/slop/parser.rb
@@ -44,8 +44,13 @@ module Slop
       @arguments = strings.dup
 
       pairs.each do |flag, arg|
+        break if !flag
+
         # ignore everything after '--', flag or not
-        break if !flag || flag == '--'
+        if flag == '--'
+          arguments.delete(flag)
+          break
+        end
 
         # support `foo=bar`
         if flag.include?("=")

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -61,5 +61,10 @@ describe Slop::Parser do
     it "returns all unparsed arguments" do
       assert_equal %w(foo argument), @parser.arguments
     end
+
+    it "does not return --" do
+      @parser.parse %w(-v -- --name lee)
+      assert_equal %w(--name lee), @parser.arguments
+    end
   end
 end


### PR DESCRIPTION
The double dash is a valid (special) option for Slop, so like the rest of the options successfully processed, should be removed.