### PR TITLE
Implement string[] MissingArgument.flags and string UnknownOption.flag

### DIFF
--- a/lib/slop/error.rb
+++ b/lib/slop/error.rb
@@ -24,7 +24,7 @@ module Slop
 
   # Raised when an unknown option is parsed. Suppress
   # with the `suppress_errors` config option.
-  class UnknownOption   < Error;
+  class UnknownOption < Error
     attr_reader :flag
 
     def initialize(msg, flag)

--- a/lib/slop/error.rb
+++ b/lib/slop/error.rb
@@ -12,6 +12,16 @@ module Slop
   # executed without one. Suppress with the `suppress_errors`
   # config option.
   class MissingArgument < Error
+    def initialize(msg, argument)
+      super(msg)
+      @argument = argument
+    end
+
+    #Get all the flags that matches
+    #the option with the missing argument
+    def getFlags()
+      return @argument
+    end
   end
 
   # Raised when an unknown option is parsed. Suppress

--- a/lib/slop/error.rb
+++ b/lib/slop/error.rb
@@ -16,5 +16,14 @@ module Slop
 
   # Raised when an unknown option is parsed. Suppress
   # with the `suppress_errors` config option.
-  class UnknownOption   < Error; end
+  class UnknownOption   < Error;
+    def initialize(msg, unknownOption)
+      super(msg);
+      @unknownOption = unknownOption;
+    end
+
+    def getUnknowOption()
+      return @unknownOption;
+    end
+  end
 end

--- a/lib/slop/error.rb
+++ b/lib/slop/error.rb
@@ -12,15 +12,13 @@ module Slop
   # executed without one. Suppress with the `suppress_errors`
   # config option.
   class MissingArgument < Error
-    def initialize(msg, argument)
-      super(msg)
-      @argument = argument
-    end
+    attr_reader :flags; 
 
-    #Get all the flags that matches
-    #the option with the missing argument
-    def getFlags()
-      return @argument
+    # Get all the flags that matches
+    # the option with the missing argument
+    def initialize(msg, flags)
+      super(msg)
+      @flags = flags
     end
   end
 

--- a/lib/slop/error.rb
+++ b/lib/slop/error.rb
@@ -18,12 +18,12 @@ module Slop
   # with the `suppress_errors` config option.
   class UnknownOption   < Error;
     def initialize(msg, unknownOption)
-      super(msg);
-      @unknownOption = unknownOption;
+      super(msg)
+      @unknownOption = unknownOption
     end
 
     def getUnknowOption()
-      return @unknownOption;
+      return @unknownOption
     end
   end
 end

--- a/lib/slop/error.rb
+++ b/lib/slop/error.rb
@@ -12,7 +12,7 @@ module Slop
   # executed without one. Suppress with the `suppress_errors`
   # config option.
   class MissingArgument < Error
-    attr_reader :flags; 
+    attr_reader :flags
 
     # Get all the flags that matches
     # the option with the missing argument

--- a/lib/slop/error.rb
+++ b/lib/slop/error.rb
@@ -25,13 +25,11 @@ module Slop
   # Raised when an unknown option is parsed. Suppress
   # with the `suppress_errors` config option.
   class UnknownOption   < Error;
-    def initialize(msg, unknownOption)
-      super(msg)
-      @unknownOption = unknownOption
-    end
+    attr_reader :flag
 
-    def getUnknowOption()
-      return @unknownOption
+    def initialize(msg, flag)
+      super(msg)
+      @flag = flag
     end
   end
 end

--- a/lib/slop/option.rb
+++ b/lib/slop/option.rb
@@ -48,7 +48,7 @@ module Slop
       @count += 1
 
       if value.nil? && expects_argument? && !suppress_errors?
-        raise Slop::MissingArgument, "missing argument for #{flag}"
+        raise Slop::MissingArgument.new("missing argument for #{flag}", flags)
       end
 
       @value = call(value)

--- a/lib/slop/parser.rb
+++ b/lib/slop/parser.rb
@@ -102,7 +102,7 @@ module Slop
         try_process(last, arg) # send the argument to the last flag
       else
         if flag.start_with?("-") && !suppress_errors?
-          raise UnknownOption, "unknown option `#{flag}'"
+          raise UnknownOption.new "unknown option `#{flag}'", "#{flag}"
         end
       end
     end

--- a/lib/slop/parser.rb
+++ b/lib/slop/parser.rb
@@ -102,7 +102,7 @@ module Slop
         try_process(last, arg) # send the argument to the last flag
       else
         if flag.start_with?("-") && !suppress_errors?
-          raise UnknownOption.new "unknown option `#{flag}'", "#{flag}"
+          raise UnknownOption.new("unknown option `#{flag}'", "#{flag}")
         end
       end
     end

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -7,6 +7,13 @@ describe Slop::MissingArgument do
     opts = Slop::Options.new
     opts.string "-n", "--name"
     assert_raises(Slop::MissingArgument) { opts.parse %w(--name) }
+
+    #Assert returns the argument question
+    begin
+      opts.parse %w(--name)
+    rescue Slop::MissingArgument => e
+      assert_equal(e.getFlags(), ["-n", "--name"])
+    end
   end
 
   it "does not raise when errors are suppressed" do

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -26,7 +26,7 @@ describe Slop::UnknownOption do
     begin
       opts.parse %w(--foo)
     rescue Slop::UnknownOption => e
-      assert_equal(e.getUnknowOption(), "--foo");
+      assert_equal(e.getUnknowOption(), "--foo")
     end
   end
 

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -22,7 +22,7 @@ describe Slop::UnknownOption do
     opts.string "-n", "--name"
     assert_raises(Slop::UnknownOption) { opts.parse %w(--foo) }
 
-    #Assert returns the unknown option in quetion
+    #Assert returns the unknown option in question
     begin
       opts.parse %w(--foo)
     rescue Slop::UnknownOption => e

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -12,7 +12,7 @@ describe Slop::MissingArgument do
     begin
       opts.parse %w(--name)
     rescue Slop::MissingArgument => e
-      assert_equal(e.getFlags(), ["-n", "--name"])
+      assert_equal(e.flags, ["-n", "--name"])
     end
   end
 

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -33,7 +33,7 @@ describe Slop::UnknownOption do
     begin
       opts.parse %w(--foo)
     rescue Slop::UnknownOption => e
-      assert_equal(e.getUnknowOption(), "--foo")
+      assert_equal(e.flag, "--foo")
     end
   end
 

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -21,6 +21,13 @@ describe Slop::UnknownOption do
     opts = Slop::Options.new
     opts.string "-n", "--name"
     assert_raises(Slop::UnknownOption) { opts.parse %w(--foo) }
+
+    #Assert returns the unknown option in quetion
+    begin
+      opts.parse %w(--foo)
+    rescue Slop::UnknownOption => e
+      assert_equal(e.getUnknowOption(), "--foo");
+    end
   end
 
   it "does not raise when errors are suppressed" do


### PR DESCRIPTION
Allows MissingArgument and UnknownOption error classes to carry information regarding "what option/flag"

**MissingArgument** gets a second parameter in its initialize function, which takes an array of the flags matching the option which misses an argument
**MissingArgument** also gets a *string[] getFlags()* which returns these flags

**UnknownOption** get a second parameter in its initialize function, which takes the option that was unknown.
**UnknownOption** also gets a **_string[]_** *getUnknownOption()* which return the unknown option

The throwing of **UnknownOption** and **MissingArgument** has been rewritten to match the new parameter list of the initialize of these classes.
And tests have been written for the new functionality.

btw: Type in the commit message, it says "Implement getUnknownMessage in UnknownOption", meant to write, getUnknownOption