### PR TITLE
Better handling of option names with multiple words

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,19 +22,21 @@ opts = Slop.parse do |o|
   o.integer '--port', 'custom port', default: 80
   o.bool '-v', '--verbose', 'enable verbose mode'
   o.bool '-q', '--quiet', 'suppress output (quiet mode)'
+  o.bool '-c', '--check-ssl-certificate', 'check SSL certificate for host'
   o.on '--version', 'print the version' do
     puts Slop::VERSION
     exit
   end
 end
 
-ARGV #=> -v --host 192.168.0.1
+ARGV #=> -v --host 192.168.0.1 --check-ssl-certificate
 
-opts[:host]   #=> 192.168.0.1
-opts.verbose? #=> true
-opts.quiet?   #=> false
+opts[:host]                 #=> 192.168.0.1
+opts.verbose?               #=> true
+opts.quiet?                 #=> false
+opts.check_ssl_certificate? #=> true
 
-opts.to_hash  #=> { host: "192.168.0.1", port: 80, verbose: true, quiet: false }
+opts.to_hash  #=> { host: "192.168.0.1", port: 80, verbose: true, quiet: false, check_ssl_certificate: true }
 ```
 
 Option types

--- a/lib/slop/option.rb
+++ b/lib/slop/option.rb
@@ -102,7 +102,7 @@ module Slop
 
     # Returns the last key as a symbol. Used in Options.to_hash.
     def key
-      (config[:key] || flags.last.sub(/\A--?/, '')).to_sym
+      (config[:key] || flags.last.sub(/\A--?/, '')).tr("-", "_").to_sym
     end
 
     # Returns true if this option should be displayed in help text.

--- a/lib/slop/result.rb
+++ b/lib/slop/result.rb
@@ -33,7 +33,7 @@ module Slop
 
     # Returns an Option if it exists. Ignores any prefixed hyphens.
     def option(flag)
-      cleaned = -> (f) { f.to_s.sub(/\A--?/, '') }
+      cleaned = -> (f) { f.to_s.sub(/\A--?/, '').tr('_', '-') }
       options.find do |o|
         o.flags.any? { |f| cleaned.(f) == cleaned.(flag) }
       end

--- a/test/option_test.rb
+++ b/test/option_test.rb
@@ -17,6 +17,10 @@ describe Slop::Option do
       assert_equal :foo, option(%w(-f --foo), nil).key
     end
 
+    it "converts dashes to underscores to make multi-word options symbol-friendly" do
+      assert_equal :foo_bar, option(%w(-f --foo-bar), nil).key
+    end
+
     it "can be overridden" do
       assert_equal :bar, option(%w(-f --foo), nil, key: "bar").key
     end

--- a/test/result_test.rb
+++ b/test/result_test.rb
@@ -12,16 +12,18 @@ end
 
 describe Slop::Result do
   before do
-    @options = Slop::Options.new
-    @verbose = @options.bool "-v", "--verbose"
-    @name    = @options.string "--name"
-    @unused  = @options.string "--unused"
-    @result  = @options.parse %w(foo -v --name lee argument)
+    @options     = Slop::Options.new
+    @verbose     = @options.bool "-v", "--verbose"
+    @name        = @options.string "--name"
+    @unused      = @options.string "--unused"
+    @long_option = @options.string "--long-option"
+    @result      = @options.parse %w(foo -v --name lee --long-option bar argument)
   end
 
   it "increments option count" do
     # test this here so it's more "full stack"
     assert_equal 1, @verbose.count
+    assert_equal 1, @long_option.count
     @result.parser.parse %w(-v --verbose)
     assert_equal 2, @verbose.count
   end
@@ -51,6 +53,9 @@ describe Slop::Result do
       assert_equal "lee", @result["name"]
       assert_equal "lee", @result[:name]
       assert_equal "lee", @result["--name"]
+      assert_equal "bar", @result["long_option"]
+      assert_equal "bar", @result[:long_option]
+      assert_equal "bar", @result["--long-option"]
     end
   end
 
@@ -72,6 +77,7 @@ describe Slop::Result do
     it "checks if options have been used" do
       assert_equal true, @result.verbose?
       assert_equal false, @result.unused?
+      assert_equal true, @result.long_option?
     end
   end
 
@@ -79,6 +85,7 @@ describe Slop::Result do
     it "returns an option by flag" do
       assert_equal @verbose, @result.option("--verbose")
       assert_equal @verbose, @result.option("-v")
+      assert_equal @long_option, @result.option("--long-option")
     end
 
     it "ignores prefixed hyphens" do
@@ -93,7 +100,8 @@ describe Slop::Result do
 
   describe "#to_hash" do
     it "returns option keys and values" do
-      assert_equal({ verbose: true, name: "lee", unused: nil }, @result.to_hash)
+      assert_equal({ verbose: true, name: "lee", unused: nil, long_option: "bar" },
+                   @result.to_hash)
     end
   end
 end


### PR DESCRIPTION
At the moment, the behaviour is a bit odd for options with multiple word names (e.g. `--long-option-name`) where you end up with strange behaviour on `Slop::Result` where you end up with odd symbol keys, which look like `:"long-option-name"` rather than `:long_option_name` as you'd naturally expected.

I've made various fixes to make this work as you'd expect, as well as supporting features like the `?` accessor methods.

Keen to hear your thoughts on this. Seems like a nicer and more idiomatic Ruby behaviour. Tested it somewhat but you may well have a view on testing it more or less.