### PR TITLE
add a duplicate option to help

### DIFF
--- a/lib/slop/option.rb
+++ b/lib/slop/option.rb
@@ -126,9 +126,24 @@ module Slop
       tail? ? 1 : -1
     end
 
+    # Returns a metavariable to be used as the name of a flag in help
+    def metavar(check_defaults: true)
+      if expects_argument?
+        metavar = (
+          config[:metavar] ||
+          flags.max_by(&:size).sub(/\A--?/, '').tr("-", "_").upcase
+        )
+        if check_defaults
+          metavar = "[#{metavar}]" unless default_value.nil?
+        end
+        metavar
+      end
+    end
+
     # Returns the help text for this option (flags and description).
-    def to_s(offset: 0)
-      "%-#{offset}s  %s" % [flag, desc]
+    def to_s(offset: 0, metavar_offset: 0)
+      metavar_offset += 1 unless metavar_offset.zero?
+      "%-#{offset}s %-#{metavar_offset}s %s" % [flag, metavar, desc]
     end
   end
 end

--- a/lib/slop/option.rb
+++ b/lib/slop/option.rb
@@ -47,11 +47,16 @@ module Slop
     def ensure_call(value)
       @count += 1
 
-      if value.nil? && expects_argument? && !suppress_errors?
-        raise Slop::MissingArgument.new("missing argument for #{flag}", flags)
+      if value.nil? && expects_argument?
+        if default_value
+          @value = default_value
+        elsif !suppress_errors?
+          raise Slop::MissingArgument.new("missing argument for #{flag}", flags)
+        end
+      else
+        @value = call(value)
       end
 
-      @value = call(value)
       block.call(@value) if block.respond_to?(:call)
     end
 

--- a/lib/slop/options.rb
+++ b/lib/slop/options.rb
@@ -100,6 +100,7 @@ module Slop
     def to_s(prefix: " " * 4)
       str = config[:banner] ? "#{banner}\n" : ""
       len = longest_flag_length
+      metavar_len = longest_metavar_length
 
       options.select(&:help?).sort_by(&:tail).each_with_index do |opt, i|
         # use the index to fetch an associated separator
@@ -107,7 +108,7 @@ module Slop
           str << "#{sep}\n"
         end
 
-        str << "#{prefix}#{opt.to_s(offset: len)}\n"
+        str << "#{prefix}#{opt.to_s(offset: len, metavar_offset: metavar_len)}\n"
       end
 
       str
@@ -121,6 +122,15 @@ module Slop
 
     def longest_option
       options.max { |a, b| a.flag.length <=> b.flag.length }
+    end
+
+    def longest_metavar_length
+      (m = longest_metavar) && m.metavar.length || 0
+    end
+
+    def longest_metavar
+      options.select(&:expects_argument?).
+        max { |a, b| a.metavar.length <=> b.metavar.length }
     end
 
     def add_option(option)

--- a/lib/slop/types.rb
+++ b/lib/slop/types.rb
@@ -76,6 +76,14 @@ module Slop
     def limit
       config[:limit] || 0
     end
+
+    def metavar
+      metavar = super(check_defaults: false)
+      metavar = "#{metavar}[#{delimiter}#{metavar}...]"
+      default_value.empty? ?
+        metavar :
+        "[#{metavar}]"
+    end
   end
 
   # Cast the option argument to a Regexp.

--- a/test/result_test.rb
+++ b/test/result_test.rb
@@ -32,6 +32,9 @@ describe Slop::Result do
     @options.string("--foo", default: "bar")
     @result.parser.parse %w()
     assert_equal "bar", @result[:foo]
+
+    @result.parser.parse %w(--foo)
+    assert_equal "bar", @result[:foo]
   end
 
   it "handles custom finishing" do


### PR DESCRIPTION
uses separators to add a duplicate option to help but not to options; useful for grouping options in help.