### PR TITLE
Add python-argparse style `metavar` for option help

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ help string to display your options. Just `puts opts` or call `opts.to_s`:
 opts = Slop.parse do |o|
   o.string '-h', '--host', 'hostname'
   o.int '-p', '--port', 'port (default: 80)', default: 80
-  o.string '--username'
+  o.string '--username', metavar: 'USER'
   o.separator ''
   o.separator 'other options:'
   o.bool '--quiet', 'suppress output'
@@ -233,12 +233,12 @@ Output:
 ```
 % ruby run.rb
 usage: run.rb [options]
-    -h, --host     hostname
-    -p, --port     port (default: 80)
-    --username
+    -h, --host    HOST    hostname
+    -p, --port    [PORT]  port (default: 80)
+    --username    USER
 
 other options:
-    --quiet        suppress output
+    --quiet               suppress output
     -v, --version
 ```
 

--- a/lib/slop/option.rb
+++ b/lib/slop/option.rb
@@ -121,9 +121,22 @@ module Slop
       tail? ? 1 : -1
     end
 
+    # Returns a metavariable to be used as the name of a flag in help
+    def metavar(check_defaults: true)
+      if expects_argument?
+        metavar = (
+          config[:metavar] ||
+          flags.max_by(&:size).sub(/\A--?/, '').tr("-", "_").upcase
+        )
+        metavar = "[#{metavar}]" if check_defaults and default_value
+        metavar
+      end
+    end
+
     # Returns the help text for this option (flags and description).
-    def to_s(offset: 0)
-      "%-#{offset}s  %s" % [flag, desc]
+    def to_s(offset: 0, metavar_offset: 0)
+      metavar_offset += 1 unless metavar_offset.zero?
+      "%-#{offset}s %-#{metavar_offset}s %s" % [flag, metavar, desc]
     end
   end
 end

--- a/lib/slop/options.rb
+++ b/lib/slop/options.rb
@@ -100,6 +100,7 @@ module Slop
     def to_s(prefix: " " * 4)
       str = config[:banner] ? "#{banner}\n" : ""
       len = longest_flag_length
+      metavar_len = longest_metavar_length
 
       options.select(&:help?).sort_by(&:tail).each_with_index do |opt, i|
         # use the index to fetch an associated separator
@@ -107,7 +108,7 @@ module Slop
           str << "#{sep}\n"
         end
 
-        str << "#{prefix}#{opt.to_s(offset: len)}\n"
+        str << "#{prefix}#{opt.to_s(offset: len, metavar_offset: metavar_len)}\n"
       end
 
       str
@@ -121,6 +122,15 @@ module Slop
 
     def longest_option
       options.max { |a, b| a.flag.length <=> b.flag.length }
+    end
+
+    def longest_metavar_length
+      (m = longest_metavar) && m.metavar.length || 0
+    end
+
+    def longest_metavar
+      options.select(&:expects_argument?).
+        max { |a, b| a.metavar.length <=> b.metavar.length }
     end
 
     def add_option(option)

--- a/lib/slop/types.rb
+++ b/lib/slop/types.rb
@@ -76,6 +76,14 @@ module Slop
     def limit
       config[:limit] || 0
     end
+
+    def metavar
+      metavar = super(check_defaults: false)
+      metavar = "#{metavar}[#{delimiter}#{metavar}...]"
+      default_value.empty? ?
+        metavar :
+        "[#{metavar}]"
+    end
   end
 
   # Cast the option argument to a Regexp.

--- a/test/option_test.rb
+++ b/test/option_test.rb
@@ -25,4 +25,19 @@ describe Slop::Option do
       assert_equal :bar, option(%w(-f --foo), nil, key: "bar").key
     end
   end
+
+  describe "#metavar" do
+    it "will be nil unless #expects_argument?" do
+      assert_nil Slop::BoolOption.new(%w(--foo), nil).metavar
+    end
+    it "will be the uppercased name of the longest flag by default" do
+      assert_equal "FOO", Slop::Option.new(%w(--foo -f), nil).metavar
+    end
+    it "can be overridden" do
+      assert_equal "BAR", Slop::Option.new(%w(--foo), nil, metavar: 'BAR').metavar
+    end
+    it "will be surrounded by square brackets if it has a default" do
+      assert_equal "[FOO]", Slop::Option.new(%w(--foo), nil, default: "bar").metavar
+    end
+  end
 end

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -66,6 +66,13 @@ describe Slop::Options do
       assert_match(/^    -s         short/, @options.to_s)
     end
 
+    it "aligns option strings with metavars" do
+      @options.on "-b", "--bar", "a bear", type: 'String'
+      @options.on "--foo", "fooey"
+      assert_match(/^    -b, --bar BAR  a bear/, @options.to_s)
+      assert_match(/^    --foo          fooey/, @options.to_s)
+    end
+
     it "can use a custom prefix" do
       @options.on "-f", "--foo"
       assert_match(/^ -f, --foo/, @options.to_s(prefix: " "))

--- a/test/types_test.rb
+++ b/test/types_test.rb
@@ -63,6 +63,7 @@ describe Slop::ArrayOption do
     @files   = @options.array "--files"
     @delim   = @options.array "-d", delimiter: ":"
     @limit   = @options.array "-l", limit: 2
+    @defval  = @options.array "--foo", default: 'bar'
     @result  = @options.parse %w(--files foo.txt,bar.rb)
   end
 
@@ -87,6 +88,20 @@ describe Slop::ArrayOption do
   it "can use a custom limit" do
     @result.parser.parse %w(-l foo,bar,baz)
     assert_equal ["foo", "bar,baz"], @result[:l]
+  end
+
+  describe "#metavar" do
+    it "will use ellipsis to denote multiple arguments" do
+      assert_equal "FILES[,FILES...]", @files.metavar
+    end
+
+    it "can use a custom delimiter" do
+      assert_equal "D[:D...]", @delim.metavar
+    end
+
+    it "will be surrounded by square brackets if it has a default" do
+      assert_equal "[FOO[,FOO...]]", @defval.metavar
+    end
   end
 end
 


### PR DESCRIPTION
Display an example variable in help to distinguish boolean flags from options with arguments.
