### PR TITLE
Fix bug where true is passed to BoolOption block regardless of --no- prefix

### DIFF
--- a/lib/slop/types.rb
+++ b/lib/slop/types.rb
@@ -16,7 +16,7 @@ module Slop
 
     def call(value)
       self.explicit_value = value
-      true
+      !force_false?
     end
 
     def value
@@ -92,5 +92,4 @@ module Slop
       true
     end
   end
-
 end

--- a/test/types_test.rb
+++ b/test/types_test.rb
@@ -6,7 +6,9 @@ describe Slop::BoolOption do
     @verbose  = @options.bool "--verbose"
     @quiet    = @options.bool "--quiet"
     @inversed = @options.bool "--inversed", default: true
-    @result   = @options.parse %w(--verbose --no-inversed)
+    @bloc     = @options.bool("--bloc"){|val| (@bloc_val ||= []) << val}
+    @result   = @options.parse %w(--verbose --no-inversed
+                                  --bloc --no-bloc)
   end
 
   it "returns true if used" do
@@ -19,6 +21,10 @@ describe Slop::BoolOption do
 
   it "can be inversed via --no- prefix" do
     assert_equal false, @result[:inversed]
+  end
+
+  it "will invert the value passed to &block via --no- prefix" do
+    assert_equal [true, false], @bloc_val
   end
 end
 


### PR DESCRIPTION
The --no- prefix was setting the final option correctly, but always passing true as the block argument regardless - see tests.