### PR TITLE
Allow disabling the delimiter for array arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ end
 # --files foo.txt --files bar.rb
 ```
 
+If you want to disable the built-in string-splitting, set the delimiter to
+`nil`.
+
 Custom option types
 -------------------
 

--- a/lib/slop/types.rb
+++ b/lib/slop/types.rb
@@ -62,7 +62,11 @@ module Slop
   class ArrayOption < Option
     def call(value)
       @value ||= []
-      @value.concat value.split(delimiter, limit)
+      if delimiter
+        @value.concat value.split(delimiter, limit)
+      else
+        @value << value
+      end
     end
 
     def default_value
@@ -70,7 +74,7 @@ module Slop
     end
 
     def delimiter
-      config[:delimiter] || ","
+      config.fetch(:delimiter, ",")
     end
 
     def limit

--- a/test/types_test.rb
+++ b/test/types_test.rb
@@ -67,6 +67,7 @@ describe Slop::ArrayOption do
   before do
     @options = Slop::Options.new
     @files   = @options.array "--files"
+    @multi   = @options.array "-M", delimiter: nil
     @delim   = @options.array "-d", delimiter: ":"
     @limit   = @options.array "-l", limit: 2
     @result  = @options.parse %w(--files foo.txt,bar.rb)
@@ -83,6 +84,11 @@ describe Slop::ArrayOption do
   it "collects multiple option values" do
     @result.parser.parse %w(--files foo.txt --files bar.rb)
     assert_equal %w(foo.txt bar.rb), @result[:files]
+  end
+
+  it "collects multiple option values with no delimiter" do
+    @result.parser.parse %w(-M foo,bar -M bar,qux)
+    assert_equal %w(foo,bar bar,qux), @result[:M]
   end
 
   it "can use a custom delimiter" do


### PR DESCRIPTION
I'd like to allow my users to supply an argument multiple times on the command line, which slop supports, but the arguments can contain commas. Instead of setting the delimiter to something silly like `thisisnotadelimiter` or `_________` or `\0` to prevent unintended behavior, allow disabling the delimiter by setting it to `nil`. 

UPDATE: Well, I just realized that I can simply set the array option limit to one (1) to get the behavior I'm looking for. I'll leave this PR open in case you think it's still useful to add. Thank you...