### PR TITLE
Can specify a custom banner string in Options via config

### DIFF
--- a/lib/slop/options.rb
+++ b/lib/slop/options.rb
@@ -26,7 +26,7 @@ module Slop
     def initialize(**config)
       @options    = []
       @separators = []
-      @banner     = "usage: #{$0} [options]"
+      @banner     = config[:banner].is_a?(String) ? config[:banner] : config.fetch(:banner, "usage: #{$0} [options]")
       @config     = DEFAULT_CONFIG.merge(config)
       @parser     = Parser.new(self, @config)
 

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -55,7 +55,7 @@ describe Slop::Options do
   end
 
   describe "#to_s" do
-    it "is prefixed with the banner" do
+    it "is prefixed with the default banner" do
       assert_match(/^usage/, @options.to_s)
     end
 
@@ -80,6 +80,17 @@ describe Slop::Options do
       @options.on "-h", "--help", tail: true
       @options.on "-f", "--foo"
       assert_match(/^    -h, --help/, @options.to_s.lines.last)
+    end
+  end
+
+  describe "custom banner" do
+    it "is prefixed with defined banner" do
+      @options_config = Slop::Options.new({banner: "custom banner"})
+      assert_match(/^custom banner/, @options_config.to_s) 
+    end
+    it "banner is disabled" do
+      @options_config = Slop::Options.new({banner: false})
+      assert_match("", @options_config.to_s)
     end
   end
 end


### PR DESCRIPTION
The usage message displays the script name as the entire path of when the script was called. If the script is called from a directory other than the one it is in, it will display that entire path. 

See here for an example showing several parent directories in the usage:
![image](https://cloud.githubusercontent.com/assets/6665997/13793915/b6bce622-eacf-11e5-895a-2f334bde2ee2.png)

This lets the user specify a banner string via the config hash to allow them to override the text shown in the banner.