### PR TITLE
inside tail sort, retain original sort order

### DIFF
--- a/lib/slop/options.rb
+++ b/lib/slop/options.rb
@@ -101,7 +101,7 @@ module Slop
       str = config[:banner] ? "#{banner}\n" : ""
       len = longest_flag_length
 
-      options.select(&:help?).sort_by(&:tail).each_with_index do |opt, i|
+      options.select(&:help?).each_with_index.sort_by{ |o,i| [o.tail, i] }.each do |opt, i|
         # use the index to fetch an associated separator
         if sep = separators[i]
           str << "#{sep}\n"


### PR DESCRIPTION
`sort_by` does not ensure the original order is kept for sequences with the same sort value.

This fixes it by keeping the original index as a secondary sort param.