### PR TITLE
Travis: use 2.4.0, latest stable JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
-  - 2.3.0
+  - 2.3.3
+  - 2.4.0
+  - jruby-9.1.8.0
   - jruby-head
   - ruby-head
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 cache: bundler
 before_install:
-  - gem update bundler
+  - gem install bundler
 rvm:
   - 2.0.0
   - 2.1
@@ -10,10 +10,6 @@ rvm:
   - jruby-9.1.8.0
   - jruby-head
   - ruby-head
-matrix:
-  allow_failures:
-    - rvm: ruby-head
-    - rvm: jruby-head
 notifications:
   email:
     on_success: change


### PR DESCRIPTION
This PR introduces 2 new Rubies to the matrix: latest stable Ruby and JRuby.

It changes `gem update bundler` to `gem install bundler`. (Why? "gem update bundler" is a noop is there's no `bundler` gem installed, which was the case in `jruby-head`, which led to a build failure because the default shell script that runs "bundle install ..." failed with a "can not find `bundler`".)