### PR TITLE
Travis: jruby-9.1.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.2
   - 2.3.4
   - 2.4.1
-  - jruby-9.1.8.0
+  - jruby-9.1.10.0
   - jruby-head
   - ruby-head
 notifications:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.