### PR TITLE
Fix bug preventing '--' being passed as the first argument.

### DIFF
--- a/lib/slop/parser.rb
+++ b/lib/slop/parser.rb
@@ -148,6 +148,7 @@ module Slop
     def partition(strings)
       if strings.include?("--")
         partition_idx = strings.index("--")
+        return [[], strings[1..-1]] if partition_idx.zero?
         [strings[0..partition_idx-1], strings[partition_idx+1..-1]]
       else
         [strings, []]

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -21,6 +21,12 @@ describe Slop::MissingArgument do
     opts.string "-n", "--name"
     opts.parse %w(--name)
   end
+
+  it "does not raise if '--' appears as the first argument" do
+    opts = Slop::Options.new
+    opts.string "-n", "--name"
+    opts.parse %w(-- --name)
+  end
 end
 
 describe Slop::UnknownOption do


### PR DESCRIPTION
There's an oversight in the `partition` method (which treats all arguments following `--` as ignored arguments) where it does not work correctly if `partition_idx` is zero (i.e. `--` is the first element in the string array). This patch fixes this erroneous behavior and adds a small spec for it.