### PR TITLE
README: Fix example to include required option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,15 @@ opts = Slop.parse do |o|
   end
 end
 
-ARGV #=> -v --host 192.168.0.1 --check-ssl-certificate
+ARGV #=> -v --login alice --host 192.168.0.1 --check-ssl-certificate
 
 opts[:host]                 #=> 192.168.0.1
+opts[:login]                #=> alice
 opts.verbose?               #=> true
 opts.quiet?                 #=> false
 opts.check_ssl_certificate? #=> true
 
-opts.to_hash  #=> { host: "192.168.0.1", port: 80, verbose: true, quiet: false, check_ssl_certificate: true }
+opts.to_hash  #=> { host: "192.168.0.1", login: "alice", port: 80, verbose: true, quiet: false, check_ssl_certificate: true }
 ```
 
 Note that the block we've added to the `--version` flag will be executed


### PR DESCRIPTION
Follows up on #218 -- I only half updated the example there, and left out the new option in the `opts` and `opts.to_hash` demonstrations.  Sorry!