### PR TITLE
Travis: use JRuby 9.1.16.0 in the CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.2
   - 2.3.4
   - 2.4.1
-  - jruby-9.1.15.0
+  - jruby-9.1.16.0
   - jruby-head
   - ruby-head
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.2
   - 2.3.4
   - 2.4.1
-  - jruby-9.1.13.0
+  - jruby-9.1.15.0
   - jruby-head
   - ruby-head
 notifications:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/12/07/jruby-9-1-15-0.html