### PR TITLE
Add Slop::Result#fetch

### DIFF
--- a/lib/slop/error.rb
+++ b/lib/slop/error.rb
@@ -22,8 +22,9 @@ module Slop
     end
   end
 
-  # Raised when an unknown option is parsed. Suppress
-  # with the `suppress_errors` config option.
+  # Raised when an unknown option is parsed or when trying to fetch an
+  # unexisting option via `Slop::Result#fetch`.
+  # Suppress with the `suppress_errors` config option.
   class UnknownOption < Error
     attr_reader :flag
 

--- a/test/result_test.rb
+++ b/test/result_test.rb
@@ -62,6 +62,31 @@ describe Slop::Result do
     end
   end
 
+  describe "#fetch" do
+    it "returns an options value" do
+      assert_equal "lee", @result.fetch("--name")
+    end
+
+    it "raises Slop::UnknownOption when an option does not exists" do
+      e = assert_raises(Slop::UnknownOption) { @result.fetch("--unexisting") }
+      assert_equal "option not found: 'unexisting'", e.message
+    end
+
+    it "returns the default value of an option when a value is not provided" do
+      @options.string("--foo", default: "bar")
+      @result.parser.parse %w(--foo)
+
+      assert_equal 'bar', @result.fetch('foo')
+    end
+
+    it "returns nil when an option is not provided and it does not have a default value" do
+      @options.string("--hello")
+      @result.parser.parse %w()
+
+      assert_equal nil, @result.fetch('hello')
+    end
+  end
+
   describe "#[]=" do
     it "sets an options value" do
       assert_equal "lee", @result["name"]


### PR DESCRIPTION
Sometimes I want to raise an error when a given key is not present (for avoid typos for example) so this change implements Slop::Result#fetch allows the following:

```ruby
opts = Slop.parse do |o|
  o.string '-name'
end

ARGV #=> --name giovanni

opts[:name]          # giovanni
opts.fetch(:name) # giovanni

opts.fetch(:namr)      # raises KeyError: key not found: 'namr'
opts.fetch(:last_name) # raises KeyError: key not found: 'last_name'
```

`Slop::Result#fetch` returns the value associated to a given key as `Slop::Result#[]`  and `Slop::Result#get` but raises `KeyError` if it does not exist.