### PR TITLE
CI: On Rubies < 2.3 install Bundler < 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 cache: bundler
 before_install:
-  - gem install bundler
+  - |
+    export RVM_CURRENT=`rvm current|cut -c6-8`
+    if [ "${RVM_CURRENT}" = "2.0" ] || \
+       [ "${RVM_CURRENT}" = "2.1" ] || \
+       [ "${RVM_CURRENT}" = "2.2" ]; then
+      gem install bundler -v '< 2'
+    fi
+
 rvm:
   - 2.0.0
   - 2.1


### PR DESCRIPTION
This PR installs Bundler "before 2.0" on the CI matrix Rubies which do not support Bundler 2.0+.

It asks `rvm current` for a current version number as a string, cuts it, and string-compares the result.

