### PR TITLE
Fix a bug that flag value is processed as flag

### DIFF
--- a/lib/slop/parser.rb
+++ b/lib/slop/parser.rb
@@ -64,7 +64,7 @@ module Slop
           if opt.expects_argument?
 
             # if we consumed the argument, remove the next pair
-            if orig_arg == opt.value.to_s
+            if consume_next_argument?(orig_flag)
               pairs.delete_at(idx + 1)
             end
 
@@ -105,6 +105,13 @@ module Slop
     end
 
     private
+
+    def consume_next_argument?(flag)
+      return false if flag.include?("=")
+      return true if flag.start_with?("--")
+      return true if /\A-[a-zA-Z]\z/ === flag
+      false
+    end
 
     # We've found an option, process and return it
     def process(option, arg)

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -35,6 +35,12 @@ describe Slop::Parser do
     assert_equal "--sometext", @result[:text]
   end
 
+  it "parses regexp arg with leading -" do
+    @options.regexp "--pattern"
+    @result.parser.parse %w(--pattern -x)
+    assert_equal(/-x/, @result[:pattern])
+  end
+
   it "parses negative integer" do
     @options.integer "-p", "--port"
     @result.parser.parse %w(--name=bob --port -123)


### PR DESCRIPTION
If flag value starts with "-", unknown option error is raised.

The current flag value check is "orig_arg == opt.value.to_s". There
are some objects such as Regexp and Time that input value and its #to_s
aren't same.