### PR TITLE
Support '+' as prefix for integer

### DIFF
--- a/lib/slop/types.rb
+++ b/lib/slop/types.rb
@@ -44,7 +44,7 @@ module Slop
   # Cast the option argument to an Integer.
   class IntegerOption < Option
     def call(value)
-      value =~ /\A-?\d+\z/ && value.to_i
+      value =~ /\A[+-]?\d+\z/ && value.to_i
     end
   end
   IntOption = IntegerOption

--- a/test/types_test.rb
+++ b/test/types_test.rb
@@ -32,11 +32,15 @@ describe Slop::IntegerOption do
   before do
     @options = Slop::Options.new
     @age     = @options.integer "--age"
-    @result  = @options.parse %w(--age 20)
+    @minus   = @options.integer "--minus"
+    @plus    = @options.integer "--plus"
+    @result  = @options.parse %w(--age 20 --minus -10 --plus +30)
   end
 
   it "returns the value as an integer" do
     assert_equal 20, @result[:age]
+    assert_equal -10, @result[:minus]
+    assert_equal 30, @result[:plus]
   end
 
   it "returns nil for non-numbers by default" do


### PR DESCRIPTION
Right now, if I have define
````
        opts.integer '--modify-capacity',
                     'Modify the desired ECS cluster size (defaults to zero, which means no change)',
                     default: 0
````
and call it with `command --modify-capacity +50`, slop doesn't recognise it as `50`, but instead uses `0`, which is default value. Simple change into regular expression should solve this issue (unless it breaks some other functionality in slop).