### PR TITLE
remove unused variable

### DIFF
--- a/lib/slop/parser.rb
+++ b/lib/slop/parser.rb
@@ -52,7 +52,6 @@ module Slop
 
         # support `foo=bar`
         orig_flag = flag.dup
-        orig_arg = arg
         if match = flag.match(/([^=]+)=([^=]+)/)
           flag, arg = match.captures
         end


### PR DESCRIPTION
Silences the warning about this variable not being used.

```
...slop/parser.rb:55: warning: assigned but unused variable - orig_arg
```

Looks like this was added [here](https://github.com/leejarvis/slop/commit/7f6aef195716989d8fb7e66b1ca52e348551b67a) and the usage was removed [here](https://github.com/leejarvis/slop/commit/c026ee99247c33130addc01d1399e71b14879f38#diff-20549db7eca9a25c33580b3f08335fb4).