### PR TITLE
Fixes warnings with Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ rvm:
   - 2.4.9
   - 2.5.7
   - 2.6.5
+  - 2.7.0
   - jruby-9.2.9.0
   - jruby-head
   - ruby-head

--- a/lib/slop.rb
+++ b/lib/slop.rb
@@ -20,7 +20,7 @@ module Slop
   #
   # Returns a Slop::Result.
   def self.parse(items = ARGV, **config, &block)
-    Options.new(config, &block).parse(items)
+    Options.new(**config, &block).parse(items)
   end
 
   # Example:

--- a/lib/slop/options.rb
+++ b/lib/slop/options.rb
@@ -29,7 +29,7 @@ module Slop
       @separators = []
       @banner     = config[:banner].is_a?(String) ? config[:banner] : config.fetch(:banner, "usage: #{$0} [options]")
       @config     = DEFAULT_CONFIG.merge(config)
-      @parser     = Parser.new(self, @config)
+      @parser     = Parser.new(self, **@config)
 
       yield self if block_given?
     end
@@ -52,7 +52,7 @@ module Slop
       desc   = flags.pop unless flags.last.start_with?('-')
       config = self.config.merge(config)
       klass  = Slop.string_to_option_class(config[:type].to_s)
-      option = klass.new(flags, desc, config, &block)
+      option = klass.new(flags, desc, **config, &block)
 
       add_option option
     end
@@ -82,7 +82,7 @@ module Slop
     def method_missing(name, *args, **config, &block)
       if respond_to_missing?(name)
         config[:type] = name
-        on(*args, config, &block)
+        on(*args, **config, &block)
       else
         super
       end


### PR DESCRIPTION
Thanks for this great gem!

This PR fixes a number of `Using the last argument as keyword parameters is deprecated` warnings with Ruby 2.7.

Note: there a still a few warnings generated from the tests - this just fixes the ones in code