### PR TITLE
Tests on Ruby 2.7.0: avoid warnings; add 2.7.0 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ rvm:
   - 2.4.9
   - 2.5.7
   - 2.6.5
+  - 2.7.0
   - jruby-9.2.9.0
   - jruby-head
   - ruby-head

--- a/lib/slop/options.rb
+++ b/lib/slop/options.rb
@@ -24,12 +24,12 @@ module Slop
     # The String banner prefixed to the help string.
     attr_accessor :banner
 
-    def initialize(**config)
+    def initialize(**config, &block)
       @options    = []
       @separators = []
       @banner     = config[:banner].is_a?(String) ? config[:banner] : config.fetch(:banner, "usage: #{$0} [options]")
       @config     = DEFAULT_CONFIG.merge(config)
-      @parser     = Parser.new(self, @config)
+      @parser     = Parser.new(self, **@config)
 
       yield self if block_given?
     end
@@ -52,7 +52,7 @@ module Slop
       desc   = flags.pop unless flags.last.start_with?('-')
       config = self.config.merge(config)
       klass  = Slop.string_to_option_class(config[:type].to_s)
-      option = klass.new(flags, desc, config, &block)
+      option = klass.new(flags, desc, **config, &block)
 
       add_option option
     end
@@ -82,7 +82,7 @@ module Slop
     def method_missing(name, *args, **config, &block)
       if respond_to_missing?(name)
         config[:type] = name
-        on(*args, config, &block)
+        on(*args, **config, &block)
       else
         super
       end

--- a/test/option_test.rb
+++ b/test/option_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
 describe Slop::Option do
-  def option(*args)
-    Slop::Option.new(*args)
+  def option(*args, **kwargs, &block)
+    Slop::Option.new(*args, **kwargs, &block)
   end
 
   describe "#flag" do

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -121,11 +121,11 @@ describe Slop::Options do
 
   describe "custom banner" do
     it "is prefixed with defined banner" do
-      @options_config = Slop::Options.new({banner: "custom banner"})
+      @options_config = Slop::Options.new(**{banner: "custom banner"})
       assert_match(/^custom banner/, @options_config.to_s)
     end
     it "banner is disabled" do
-      @options_config = Slop::Options.new({banner: false})
+      @options_config = Slop::Options.new(**{banner: false})
       assert_match("", @options_config.to_s)
     end
   end

--- a/test/types_test.rb
+++ b/test/types_test.rb
@@ -39,7 +39,7 @@ describe Slop::IntegerOption do
 
   it "returns the value as an integer" do
     assert_equal 20, @result[:age]
-    assert_equal -10, @result[:minus]
+    assert_equal (-10), @result[:minus]
     assert_equal 30, @result[:plus]
   end
 


### PR DESCRIPTION
Fixing tests to work with ruby 2.7.0 (also tested with ruby 2.6.3 and 2.5.1)

With current master, we stumble into following error messages on ruby 2.7.0:
```
[~/github/slop]% rake test                                                                   [master]
/Users/jylitalo/github/slop/test/types_test.rb:42: warning: ambiguous first argument; put parentheses or a space even after `-' operator
Run options: --seed 59555

# Running:

/Users/jylitalo/github/slop/lib/slop/options.rb:32: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/jylitalo/github/slop/lib/slop/parser.rb:13: warning: The called method `initialize' is defined here
/Users/jylitalo/github/slop/test/options_test.rb:124: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/jylitalo/github/slop/lib/slop/options.rb:27: warning: The called method `initialize' is defined here
./Users/jylitalo/github/slop/test/options_test.rb:128: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/jylitalo/github/slop/lib/slop/options.rb:27: warning: The called method `initialize' is defined here
./Users/jylitalo/github/slop/lib/slop/options.rb:85: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/jylitalo/github/slop/lib/slop/options.rb:51: warning: The called method `on' is defined here
/Users/jylitalo/github/slop/lib/slop/options.rb:55: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/jylitalo/github/slop/lib/slop/option.rb:30: warning: The called method `initialize' is defined here
.............................................................................../Users/jylitalo/github/slop/test/option_test.rb:5: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/jylitalo/github/slop/lib/slop/option.rb:30: warning: The called method `initialize' is defined here
....

Finished in 0.014476s, 5871.7877 runs/s, 8151.4230 assertions/s.

85 runs, 118 assertions, 0 failures, 0 errors, 0 skips
[~/github/slop]%
```

Closes #247 - thanks for that!