### PR TITLE
FloatOption: Add support for scientific notation and + sign

### DIFF
--- a/lib/slop/types.rb
+++ b/lib/slop/types.rb
@@ -52,8 +52,7 @@ module Slop
   # Cast the option argument to a Float.
   class FloatOption < Option
     def call(value)
-      # TODO: scientific notation, etc.
-      value =~ /\A[+-]?\d*\.*\d+\z/ && value.to_f
+      value =~ /\A[+-]?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+-]?\d+)?\z/ && value.to_f
     end
   end
 

--- a/lib/slop/types.rb
+++ b/lib/slop/types.rb
@@ -53,7 +53,7 @@ module Slop
   class FloatOption < Option
     def call(value)
       # TODO: scientific notation, etc.
-      value =~ /\A-?\d*\.*\d+\z/ && value.to_f
+      value =~ /\A[+-]?\d*\.*\d+\z/ && value.to_f
     end
   end
 

--- a/lib/slop/types.rb
+++ b/lib/slop/types.rb
@@ -51,8 +51,10 @@ module Slop
 
   # Cast the option argument to a Float.
   class FloatOption < Option
+    FLOAT_STRING_REGEXP = /\A[+-]?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+-]?\d+)?\z/.freeze
+
     def call(value)
-      value =~ /\A[+-]?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+-]?\d+)?\z/ && value.to_f
+      value =~ FLOAT_STRING_REGEXP && value.to_f
     end
   end
 

--- a/test/types_test.rb
+++ b/test/types_test.rb
@@ -69,15 +69,19 @@ describe Slop::FloatOption do
 
   it "parses scientific notations" do
     assert_equal @scientific_notation_value, @result[:scientific_notation]
+
     @scientific_notation_value = 4E21
     @result  = @options.parse %W(--scientific-notation #{@scientific_notation_value})
     assert_equal @scientific_notation_value, @result[:scientific_notation]
+
     @scientific_notation_value = 4.0e21
     @result  = @options.parse %W(--scientific-notation #{@scientific_notation_value})
     assert_equal @scientific_notation_value, @result[:scientific_notation]
+
     @scientific_notation_value = -4e21
     @result  = @options.parse %W(--scientific-notation #{@scientific_notation_value})
     assert_equal @scientific_notation_value, @result[:scientific_notation]
+
     @scientific_notation_value = 4e-21
     @result  = @options.parse %W(--scientific-notation #{@scientific_notation_value})
     assert_equal @scientific_notation_value, @result[:scientific_notation]

--- a/test/types_test.rb
+++ b/test/types_test.rb
@@ -54,11 +54,15 @@ describe Slop::FloatOption do
     @options = Slop::Options.new
     @apr     = @options.float "--apr"
     @apr_value = 2.9
-    @result  = @options.parse %W(--apr #{@apr_value})
+    @minus = @options.float "--minus"
+    @plus = @options.float "--plus"
+    @result  = @options.parse %W(--apr #{@apr_value} --minus -6.1 --plus +9.4)
   end
 
   it "returns the value as a float" do
     assert_equal @apr_value, @result[:apr]
+    assert_equal (-6.1), @result[:minus]
+    assert_equal 9.4, @result[:plus]
   end
 
   it "returns nil for non-numbers by default" do

--- a/test/types_test.rb
+++ b/test/types_test.rb
@@ -56,13 +56,31 @@ describe Slop::FloatOption do
     @apr_value = 2.9
     @minus = @options.float "--minus"
     @plus = @options.float "--plus"
-    @result  = @options.parse %W(--apr #{@apr_value} --minus -6.1 --plus +9.4)
+    @scientific_notation = @options.float "--scientific-notation"
+    @scientific_notation_value = 4e21
+    @result  = @options.parse %W(--apr #{@apr_value} --minus -6.1 --plus +9.4 --scientific-notation #{@scientific_notation_value})
   end
 
   it "returns the value as a float" do
     assert_equal @apr_value, @result[:apr]
     assert_equal (-6.1), @result[:minus]
     assert_equal 9.4, @result[:plus]
+  end
+
+  it "parses scientific notations" do
+    assert_equal @scientific_notation_value, @result[:scientific_notation]
+    @scientific_notation_value = 4E21
+    @result  = @options.parse %W(--scientific-notation #{@scientific_notation_value})
+    assert_equal @scientific_notation_value, @result[:scientific_notation]
+    @scientific_notation_value = 4.0e21
+    @result  = @options.parse %W(--scientific-notation #{@scientific_notation_value})
+    assert_equal @scientific_notation_value, @result[:scientific_notation]
+    @scientific_notation_value = -4e21
+    @result  = @options.parse %W(--scientific-notation #{@scientific_notation_value})
+    assert_equal @scientific_notation_value, @result[:scientific_notation]
+    @scientific_notation_value = 4e-21
+    @result  = @options.parse %W(--scientific-notation #{@scientific_notation_value})
+    assert_equal @scientific_notation_value, @result[:scientific_notation]
   end
 
   it "returns nil for non-numbers by default" do


### PR DESCRIPTION
- parse the float with a prepended + sign
- parse scientific notations
- remove the todo comment