### PR TITLE
CI: Use jruby-9.2.14.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ rvm:
   - 2.5.7
   - 2.6.5
   - 2.7.0
-  - jruby-9.2.11.1
+  - jruby-9.2.14.0
   - jruby-head
   - ruby-head
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ rvm:
   - 2.5.7
   - 2.6.5
   - 2.7.0
-  - jruby-9.2.9.0
+  - jruby-9.2.11.1
   - jruby-head
   - ruby-head
 jdk:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.14.0**.

[JRuby 9.2.14.0 release blog post](https://www.jruby.org/2020/12/08/jruby-9-2-14-0.html)