### PR TITLE
Add support for --opt="" for blank arguments

### DIFF
--- a/lib/slop/parser.rb
+++ b/lib/slop/parser.rb
@@ -52,7 +52,7 @@ module Slop
 
         # support `foo=bar`
         orig_flag = flag.dup
-        if match = flag.match(/([^=]+)=([^=]+)/)
+        if match = flag.match(/([^=]+)=([^=]*)/)
           flag, arg = match.captures
         end
 

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -28,6 +28,15 @@ describe Slop::Parser do
     assert_equal %w(=), @result.args
   end
 
+  it "parses flag=''" do
+    @options.string "--str"
+    @options.array "--arr", default: ["array"]
+    @result.parser.parse %(--str="" --arr="").shellsplit
+
+    assert_equal "", @result[:str]
+    assert_equal [], @result[:arr]
+  end
+
   it "parses arg with leading -" do
     @options.string "-t", "--text"
     @result.parser.parse %w(--name=bob --text --sometext)


### PR DESCRIPTION
This is especially useful when your default option value is a non-blank
value and you want users to be able to overwrite it with a blank value

Closes #266