### PR TITLE
Fix explicitly false booleans

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,19 @@ opts = Slop.parse do |o|
   o.bool '-v', '--verbose', 'enable verbose mode'
   o.bool '-q', '--quiet', 'suppress output (quiet mode)'
   o.bool '-c', '--check-ssl-certificate', 'check SSL certificate for host'
+  o.bool '-k', '--use-keychain', 'store passphrase in OS keychain'
   o.on '--version', 'print the version' do
     puts Slop::VERSION
     exit
   end
 end
 
-ARGV #=> -v --login alice --host 192.168.0.1 -m post --check-ssl-certificate
+ARGV #=> -v --login alice --host 192.168.0.1 -m post --check-ssl-certificate --use-keychain false
 
 opts[:host]                 #=> 192.168.0.1
 opts[:login]                #=> alice
 opts[:method]               #=> :post
+opts[:use_keychain]         #=> false
 opts.verbose?               #=> true
 opts.quiet?                 #=> false
 opts.check_ssl_certificate? #=> true
@@ -53,7 +55,7 @@ Built in Option types are as follows:
 
 ```ruby
 o.string  #=> Slop::StringOption, expects an argument
-o.bool    #=> Slop::BoolOption, no argument, aliased to BooleanOption
+o.bool    #=> Slop::BoolOption, argument optional, aliased to BooleanOption
 o.integer #=> Slop::IntegerOption, expects an argument, aliased to IntOption
 o.float   #=> Slop::FloatOption, expects an argument
 o.array   #=> Slop::ArrayOption, expects an argument

--- a/lib/slop/types.rb
+++ b/lib/slop/types.rb
@@ -21,6 +21,8 @@ module Slop
   class BoolOption < Option
     attr_accessor :explicit_value
 
+    FALSE_VALUES = [false, 'false', 'no', 'off', '0'].freeze
+
     def call(value)
       self.explicit_value = value
       !force_false?
@@ -35,7 +37,7 @@ module Slop
     end
 
     def force_false?
-      explicit_value == false
+      FALSE_VALUES.include?(explicit_value)
     end
 
     def default_value

--- a/test/types_test.rb
+++ b/test/types_test.rb
@@ -34,9 +34,11 @@ describe Slop::BoolOption do
     @verbose  = @options.bool "--verbose"
     @quiet    = @options.bool "--quiet"
     @inversed = @options.bool "--inversed", default: true
+    @explicit = @options.bool "--explicit"
     @bloc     = @options.bool("--bloc"){|val| (@bloc_val ||= []) << val}
     @result   = @options.parse %w(--verbose --no-inversed
-                                  --bloc --no-bloc)
+                                  --bloc --no-bloc
+                                  --explicit=false)
   end
 
   it "returns true if used" do
@@ -53,6 +55,10 @@ describe Slop::BoolOption do
 
   it "will invert the value passed to &block via --no- prefix" do
     assert_equal [true, false], @bloc_val
+  end
+
+  it "returns false when explicitly false" do
+    assert_equal false, @result[:explicit]
   end
 end
 


### PR DESCRIPTION
When a boolean option is explicitly set to `false`, e.g.:

```bash
--option=false
```

it enters slop as the string value `'false'`. This commit updates the
`BoolOption` option handler to interpret `'false'` and various other falsey
values (`false`, `'false'`, `'no'`, `'off'`, `'0'`) as logically false.