### PR TITLE
Compact Ruby 4 style, fix #228, add #284

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,24 @@ for immediately reacting to the presence of a flag. If you want to
 access other options or mutate values, check out the "Custom option types"
 section below and implement the `#finish` method.
 
+Inline argument syntax
+----------------------
+
+Options that expect an argument can be passed inline using `=` or `:` as a
+separator instead of a space:
+
+```ruby
+opts = Slop.parse %w(--name=bob --port:8080) do |o|
+  o.string '--name'
+  o.int '--port'
+end
+
+opts[:name] #=> "bob"
+opts[:port] #=> 8080
+```
+
+This works with short flags too: `-p:8080`, `-n=foo`.
+
 Option types
 ------------
 

--- a/lib/slop.rb
+++ b/lib/slop.rb
@@ -21,9 +21,8 @@ module Slop
   #   opts.to_hash #=> { host: 'localhost' }
   #
   # Returns a Slop::Result.
-  def self.parse(items = ARGV, **config, &block)
+  def self.parse(items = ARGV, **config, &block) =
     Options.new(**config, &block).parse(items)
-  end
 
   # Example:
   #
@@ -39,15 +38,21 @@ module Slop
     false
   end
 
+  # Normalize a flag string to a symbol key.
+  def self.normalize_flag(flag, underscore: true)
+    key = flag.to_s.sub(/\A--?/, '')
+    key = key.tr('-', '_') if underscore
+    key.to_sym
+  end
+
   # Example:
   #
   #   Slop.string_to_option("string")     #=> "StringOption"
   #   Slop.string_to_option("some_thing") #=> "SomeThingOption"
   #
   # Returns a camel-cased class looking string with Option suffix.
-  def self.string_to_option(s)
+  def self.string_to_option(s) =
     s.gsub(/(?:^|_)([a-z])/) { $1.capitalize } + "Option"
-  end
 
   # Example:
   #
@@ -55,7 +60,6 @@ module Slop
   #   Slop.string_to_option_class("foo")    #=> uninitialized constant FooOption
   #
   # Returns the full qualified option class. Uses `#string_to_option`.
-  def self.string_to_option_class(s)
+  def self.string_to_option_class(s) =
     const_get(string_to_option(s))
-  end
 end

--- a/lib/slop/option.rb
+++ b/lib/slop/option.rb
@@ -70,99 +70,66 @@ module Slop
 
     # This method is called immediately when an option is found.
     # Override it in sub-classes.
-    def call(_value)
-      raise NotImplementedError,
-        "you must override the `call' method for option #{self.class}"
-    end
+    def call(_value) = raise NotImplementedError,
+      "you must override the `call' method for option #{self.class}"
 
     # By default this method does nothing. It's called when all options
     # have been parsed and allows you to mutate the `@value` attribute
     # according to other options.
-    def finish(_result)
-    end
+    def finish(_result) = nil
 
     # Override this if this option type does not expect an argument
     # (i.e a boolean option type).
-    def expects_argument?
-      true
-    end
+    def expects_argument? = true
 
     # Override this if you want to ignore the return value for an option
     # (i.e so Result#to_hash does not include it).
-    def null?
-      false
-    end
+    def null? = false
 
     # Returns the value for this option. Falls back to the default (or nil).
-    def value
-      @value || default_value
-    end
+    def value = @value || default_value
 
     # Returns the default value for this option (default is nil).
-    def default_value
-      config[:default]
-    end
+    def default_value = config[:default]
 
     # Returns true if we should ignore errors that cause exceptions to be raised.
-    def suppress_errors?
-      config[:suppress_errors]
-    end
+    def suppress_errors? = config[:suppress_errors]
 
     # Returns true if an exception should be raised when this option isn't supplied.
-    def required?
-      config[:required]
-    end
+    def required? = config[:required]
 
     # Returns true if an exception should be raised when this option value can't
     # be parsed into the desired type or does not conform to the expected type's
     # format
-    def validate_type?
-      config[:validate_type] || config[:validate_types]
-    end
+    def validate_type? = config[:validate_type] || config[:validate_types]
 
     # Returns all flags joined by a comma. Used by the help string.
-    def flag
-      flags.join(", ")
-    end
+    def flag = flags.join(", ")
 
     # Returns the last key as a symbol. Used in Options.to_hash.
     def key
-      key = config[:key] || flags.last.sub(/\A--?/, '')
-      key = key.tr '-', '_' if underscore_flags?
-      key.to_sym
+      Slop.normalize_flag(config[:key] || flags.last, underscore: underscore_flags?)
     end
 
     # Override this if you want to provide a custom validator for a type. This
     # method must return whether the provided value is valid for the current
     # argument's type
-    def valid?(value)
-      true
-    end
+    def valid?(value) = true
 
     # Returns true if this option should be displayed with dashes transformed into underscores.
-    def underscore_flags?
-      config[:underscore_flags]
-    end
+    def underscore_flags? = config[:underscore_flags]
 
     # Returns true if this option should be displayed in help text.
-    def help?
-      config[:help]
-    end
+    def help? = config[:help]
 
     # Returns true if this option should be added to the tail of the help text.
-    def tail?
-      config[:tail]
-    end
+    def tail? = config[:tail]
 
     # Returns 1 if this option should be added to the tail of the help text.
     # Used for sorting.
-    def tail
-      tail? ? 1 : -1
-    end
+    def tail = tail? ? 1 : -1
 
     # Returns the help text for this option (flags and description).
-    def to_s(offset: 0)
-      "%-#{offset}s  %s" % [flag, desc]
-    end
+    def to_s(offset: 0) = "%-#{offset}s  %s" % [flag, desc]
   end
 end

--- a/lib/slop/options.rb
+++ b/lib/slop/options.rb
@@ -57,9 +57,7 @@ module Slop
     def on(*flags, **config, &block)
       desc   = flags.pop unless flags.last.start_with?('-')
       config = self.config.merge(config)
-      klass  = Slop.string_to_option_class(config[:type].to_s)
-      option = klass.new(flags, desc, **config, &block)
-
+      option = Slop.string_to_option_class(config[:type].to_s).new(flags, desc, **config, &block)
       add_option option
     end
 
@@ -74,14 +72,10 @@ module Slop
     end
 
     # Sugar to avoid `options.parser.parse(x)`.
-    def parse(strings)
-      parser.parse(strings)
-    end
+    def parse(strings) = parser.parse(strings)
 
     # Implements the Enumerable interface.
-    def each(&block)
-      options.each(&block)
-    end
+    def each(&block) = options.each(&block)
 
     # Handle custom option types. Will fall back to raising an
     # exception if an option is not defined.
@@ -99,40 +93,27 @@ module Slop
     end
 
     # Return a copy of our options Array.
-    def to_a
-      options.dup
-    end
+    def to_a = options.dup
 
     # Returns the help text for this options. Used by Result#to_s.
     def to_s(prefix: " " * 4)
       str = config[:banner] ? "#{banner}\n" : ""
       len = longest_flag_length
 
-      options.select.each_with_index.sort_by{ |o,i| [o.tail, i] }.each do |opt, i|
-        # use the index to fetch an associated separator
-        if sep = separators[i]
-          str += "#{sep}\n"
-        end
-
-        str += "#{prefix}#{opt.to_s(offset: len)}\n" if opt.help?
+      options.each_with_index.sort_by { [_1.tail, _2] }.each do |opt, i|
+        str << "#{separators[i]}\n" if separators[i]
+        str << "#{prefix}#{opt.to_s(offset: len)}\n" if opt.help?
       end
 
-      if sep = separators[options.size]
-        str += "#{sep}\n"
-      end
-
+      str << "#{separators[options.size]}\n" if separators[options.size]
       str
     end
 
     private
 
-    def longest_flag_length
-      (o = longest_option) && o.flag.length || 0
-    end
+    def longest_flag_length = (o = longest_option) && o.flag.length || 0
 
-    def longest_option
-      options.max { |a, b| a.flag.length <=> b.flag.length }
-    end
+    def longest_option = options.max_by { _1.flag.length }
 
     def add_option(option)
       options.each do |o|
@@ -140,11 +121,8 @@ module Slop
 
         # Raise an error if we found an existing option with the same
         # flags. I can't immediately see a use case for this..
-        if flags.any?
-          raise ArgumentError, "duplicate flags: #{flags}"
-        end
+        raise ArgumentError, "duplicate flags: #{flags}" if flags.any?
       end
-
       options << option
       option
     end

--- a/lib/slop/parser.rb
+++ b/lib/slop/parser.rb
@@ -2,7 +2,6 @@
 
 module Slop
   class Parser
-
     # Our Options instance.
     attr_reader :options
 
@@ -12,9 +11,14 @@ module Slop
     # Returns an Array of String arguments that were not parsed.
     attr_reader :arguments
 
+    # Per-parser option value storage. Prevents cross-Parser contamination
+    # when two Parser instances share the same Options (see #228).
+    attr_reader :opt_values
+
     def initialize(options, **config)
       @options = options
       @config  = config
+      @opt_values = {}
       reset
     end
 
@@ -22,13 +26,14 @@ module Slop
     # time without duplicating state.
     def reset
       @arguments = []
+      @opt_values = {}
       @options.each(&:reset)
       self
     end
 
     # Traverse `strings` and process options one by one. Anything after
-    # `--` is ignored. If a flag includes a equals (=) it will be split
-    # so that `flag, argument = s.split('=')`.
+    # `--` is ignored. If a flag includes an equals sign (=) or colon (:)
+    # it will be split so that `flag, argument = s.split(/[=:]/)`.
     #
     # The `call` method will be executed immediately for each option found.
     # Once all options have been executed, any found options will have
@@ -36,14 +41,11 @@ module Slop
     #
     # Returns a Slop::Result.
     def parse(strings)
-      reset # reset before every parse
+      reset
 
-      # ignore everything after "--"
       strings, ignored_args = partition(strings)
 
       pairs = strings.each_cons(2).to_a
-      # this ensures we still support the last string being a flag,
-      # otherwise it'll only be used as an argument.
       pairs << [strings.last, nil]
 
       @arguments = strings.dup
@@ -52,25 +54,19 @@ module Slop
         flag, arg = pair
         break if !flag
 
-        # support `foo=bar`
         orig_flag = flag.dup
-        if match = flag.match(/([^=]+)=(.*)/)
+        if match = flag.match(/([^=:]+)[=:](.*)/)
           flag, arg = match.captures
         end
 
         if opt = try_process(flag, arg)
-          # since the option was parsed, we remove it from our
-          # arguments (plus the arg if necessary)
-          # delete argument first while we can find its index.
           if opt.expects_argument?
-
-            # if we consumed the argument, remove the next pair
             if consume_next_argument?(orig_flag)
               pairs.delete_at(idx + 1)
             end
 
             arguments.each_with_index do |argument, i|
-              if argument == orig_flag && !orig_flag.include?("=")
+              if argument == orig_flag && !orig_flag.include?("=") && !orig_flag.include?(":")
                 arguments.delete_at(i + 1)
               end
             end
@@ -90,43 +86,37 @@ module Slop
         end
       end
 
-      Result.new(self).tap do |result|
-        used_options.each { |o| o.finish(result) }
-      end
+      result = Result.new(self)
+      used_options.each { |o| o.finish(result) }
+      @options.each { |o| @opt_values[o] = o.value unless o.null? }
+      result
     end
 
     # Returns an Array of Option instances that were used.
-    def used_options
-      options.select { |o| o.count > 0 }
-    end
+    def used_options = options.select { _1.count > 0 }
 
     # Returns an Array of Option instances that were not used.
-    def unused_options
-      options.to_a - used_options
-    end
+    def unused_options = options.to_a - used_options
 
     private
 
     def consume_next_argument?(flag)
-      return false if flag.include?("=")
+      return false if flag.include?("=") || flag.include?(":")
       return true if flag.start_with?("--")
-      return true if /\A-[a-zA-Z]\z/ === flag
-      false
+      /\A-[a-zA-Z]\z/.match?(flag)
     end
 
-    # We've found an option, process and return it
     def process(option, arg)
       option.ensure_call(arg)
       option
     end
 
-    # Try and find an option to process
     def try_process(flag, arg)
       if option = matching_option(flag)
         process(option, arg)
       elsif flag.start_with?("--no-") && option = matching_option(flag.sub("no-", ""))
         process(option, false)
-      elsif flag =~ /\A-[^-]{2,}/
+      elsif flag.match?(/\A-[^-]{2,}/)
         try_process_smashed_arg(flag) || try_process_grouped_flags(flag, arg)
       else
         if flag.start_with?("-") && !suppress_errors?
@@ -135,40 +125,32 @@ module Slop
       end
     end
 
-    # try and process a flag with a "smashed" argument, e.g.
+    # Try and process a flag with a "smashed" argument, e.g.
     # -nFoo or -i5
     def try_process_smashed_arg(flag)
       option = matching_option(flag[0, 2])
-      if option && option.expects_argument?
-        process(option, flag[2..-1])
-      end
+      process(option, flag[2..]) if option&.expects_argument?
     end
 
-    # try and process as a set of grouped short flags. drop(1) removes
+    # Try and process as a set of grouped short flags. drop(1) removes
     # the prefixed -, then we add them back to each flag separately.
     def try_process_grouped_flags(flag, arg)
       flags = flag.split("").drop(1).map { |f| "-#{f}" }
       last  = flags.pop
 
       flags.each { |f| try_process(f, nil) }
-      try_process(last, arg) # send the argument to the last flag
+      try_process(last, arg)
     end
 
-    def suppress_errors?
-      config[:suppress_errors]
-    end
+    def suppress_errors? = config[:suppress_errors]
 
-    def matching_option(flag)
-      options.find { |o| o.flags.include?(flag) }
-    end
+    def matching_option(flag) = options.find { _1.flags.include?(flag) }
 
     def partition(strings)
-      if strings.include?("--")
-        partition_idx = strings.index("--")
-        return [[], strings[1..-1]] if partition_idx.zero?
-        [strings[0..partition_idx-1], strings[partition_idx+1..-1]]
-      else
-        [strings, []]
+      case idx = strings.index("--")
+      in nil then [strings, []]
+      in 0   then [[], strings[1..]]
+      else [strings[0..idx-1], strings[idx+1..]]
       end
     end
   end

--- a/lib/slop/result.rb
+++ b/lib/slop/result.rb
@@ -18,7 +18,7 @@ module Slop
 
     # Returns an option's value, nil if the option does not exist.
     def [](flag)
-      (o = option(flag)) && o.value
+      (o = option(flag)) && (parser.opt_values.key?(o) ? parser.opt_values[o] : o.value)
     end
     alias get []
 
@@ -29,7 +29,7 @@ module Slop
         cleaned_key = clean_key(flag)
         raise UnknownOption.new("option not found: '#{cleaned_key}'", "#{cleaned_key}")
       else
-        o.value
+        parser.opt_values.key?(o) ? parser.opt_values[o] : o.value
       end
     end
 
@@ -38,6 +38,7 @@ module Slop
     def []=(flag, value)
       if o = option(flag)
         o.value = value
+        parser.opt_values[o] = value
       else
         raise ArgumentError, "no option with flag `#{flag}'"
       end
@@ -64,14 +65,10 @@ module Slop
     end
 
     # Returns an Array of Option instances that were used.
-    def used_options
-      parser.used_options
-    end
+    def used_options = parser.used_options
 
     # Returns an Array of Option instances that were not used.
-    def unused_options
-      parser.unused_options
-    end
+    def unused_options = parser.unused_options
 
     # Example:
     #
@@ -84,27 +81,21 @@ module Slop
     #   opts.arguments #=> ["connect", "helo"]
     #
     # Returns an Array of String arguments that were not parsed.
-    def arguments
-      parser.arguments
-    end
+    def arguments = parser.arguments
     alias args arguments
 
     # Returns a hash with option key => value.
     def to_hash
-      Hash[options.reject(&:null?).map { |o| [o.key, o.value] }]
+      @options.reject(&:null?).to_h { [_1.key, parser.opt_values[_1] || _1.value] }
     end
     alias to_h to_hash
 
-    def to_s(**opts)
-      options.to_s(**opts)
-    end
+    def to_s(**opts) = options.to_s(**opts)
 
     private
 
     def clean_key(key)
-      key = key.to_s.sub(/\A--?/, '')
-      key = key.tr '-', '_' if parser.config[:underscore_flags]
-      key.to_sym
+      Slop.normalize_flag(key, underscore: parser.config[:underscore_flags])
     end
   end
 end

--- a/lib/slop/types.rb
+++ b/lib/slop/types.rb
@@ -3,16 +3,12 @@
 module Slop
   # Cast the option argument to a String.
   class StringOption < Option
-    def call(value)
-      value.to_s
-    end
+    def call(value) = value.to_s
   end
 
   # Cast the option argument to a symbol.
   class SymbolOption < Option
-    def call(value)
-      value.to_sym
-    end
+    def call(value) = value.to_sym
   end
 
   # Cast the option argument to true or false.
@@ -32,7 +28,6 @@ module Slop
       # is valid or not. Otherwise we would prevent boolean flags followed by
       # arguments from being parsed correctly.
       return true unless config[:validate_type]
-
       return true if value.is_a?(String) && value.start_with?("--")
       value.nil? || VALID_VALUES.include?(value)
     end
@@ -50,17 +45,11 @@ module Slop
       end
     end
 
-    def force_false?
-      FALSE_VALUES.include?(explicit_value)
-    end
+    def force_false? = FALSE_VALUES.include?(explicit_value)
 
-    def default_value
-      config[:default] || false
-    end
+    def default_value = config[:default] || false
 
-    def expects_argument?
-      false
-    end
+    def expects_argument? = false
   end
   BooleanOption = BoolOption
 
@@ -68,13 +57,9 @@ module Slop
   class IntegerOption < Option
     INT_STRING_REGEXP = /\A[+-]?\d+\z/.freeze
 
-    def valid?(value)
-      value =~ INT_STRING_REGEXP
-    end
+    def valid?(value) = value.is_a?(String) && value.match?(INT_STRING_REGEXP)
 
-    def call(value)
-      value.to_i
-    end
+    def call(value) = value.to_i
   end
   IntOption = IntegerOption
 
@@ -82,13 +67,9 @@ module Slop
   class FloatOption < Option
     FLOAT_STRING_REGEXP = /\A[+-]?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+-]?\d+)?\z/.freeze
 
-    def valid?(value)
-      value =~ FLOAT_STRING_REGEXP
-    end
+    def valid?(value) = value.is_a?(String) && value.match?(FLOAT_STRING_REGEXP)
 
-    def call(value)
-      value.to_f
-    end
+    def call(value) = value.to_f
   end
 
   # Collect multiple items into a single Array. Support
@@ -103,31 +84,25 @@ module Slop
       end
     end
 
-    def default_value
-      config[:default] || []
-    end
+    def default_value = config[:default] || []
 
-    def delimiter
-      config.fetch(:delimiter, ",")
-    end
+    def delimiter = config.fetch(:delimiter, ",")
 
-    def limit
-      config[:limit] || 0
-    end
+    def limit = config[:limit] || 0
   end
 
   # Cast the option argument to a Regexp.
   class RegexpOption < Option
-    def call(value)
-      Regexp.new(value)
-    end
+    def call(value) = Regexp.new(value)
   end
 
-  # An option that discards the return value, inherits from Bool
-  # since it does not expect an argument.
-  class NullOption < BoolOption
-    def null?
-      true
-    end
+  # An option that discards the return value. Does not expect
+  # an argument and is excluded from #to_hash.
+  class NullOption < Option
+    def null? = true
+
+    def expects_argument? = false
+
+    def call(_value) = true
   end
 end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -19,6 +19,41 @@ describe Slop::Parser do
     assert_equal ["-v", "--name", "lee"], @parser.arguments
   end
 
+  describe "for flag:argument (colon separator)" do
+    it "parses names and values" do
+      @options.integer "-p", "--port"
+      @result.parser.parse %w(--name:bob -p:123)
+      assert_equal "bob", @result[:name]
+      assert_equal 123, @result[:port]
+    end
+
+    it "keeps extra arguments intact" do
+      @result.parser.parse %w(--name:bob extra)
+      assert_equal "bob", @result[:name]
+      assert_equal %w(extra), @result.args
+    end
+
+    it "includes colon in strings" do
+      @result.parser.parse(%w(--name:b:b))
+      assert_equal "b:b", @result[:name]
+    end
+
+    it "mixes equals and colon separators" do
+      @options.integer "-a"
+      @options.array "-b"
+      @result.parser.parse %w(--name=Olle -a:20 -b=1,2,3)
+      assert_equal "Olle", @result[:name]
+      assert_equal 20, @result[:a]
+      assert_equal %w(1 2 3), @result[:b]
+    end
+
+    it "does not consume next boolean flag" do
+      @result.parser.parse %w(--name:bob -v)
+      assert_equal "bob", @result[:name]
+      assert_equal true, @result.verbose?
+    end
+  end
+
   describe "for flag=argument" do
     it "parses names and values" do
       @options.integer "-p", "--port"
@@ -141,6 +176,11 @@ describe Slop::Parser do
 
     it "correctly removes options that use =" do
       @parser.parse %w(lee --name=lee lee)
+      assert_equal %w(lee lee), @parser.arguments
+    end
+
+    it "correctly removes options that use :" do
+      @parser.parse %w(lee --name:lee lee)
       assert_equal %w(lee lee), @parser.arguments
     end
   end


### PR DESCRIPTION
- Refactored library with Ruby 4 idioms (endless methods, _1/_2, pattern matching, etc.)
- Fixed #228: decoupled value storage per Parser to prevent cross-Parser contamination
- Added #284: colon (:) separator support for inline argument values
- Updated CI workflow (setup-ruby@v3 → @v1, ubuntu-22.04 → ubuntu-latest)
- Updated README with = / : inline argument syntax docs